### PR TITLE
change sort query name

### DIFF
--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -26,7 +26,7 @@ func CreateSearchPage(ctx context.Context, query url.Values, respC searchC.Respo
 		page.Data.Filter = strings.Split(filter, ",")
 	}
 
-	page.Data.Sort = query.Get("sortBy")
+	page.Data.Sort = query.Get("sort")
 
 	if query.Get("limit") != "" {
 		page.Data.Limit, err = strconv.Atoi(query.Get("limit"))

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -17,7 +17,7 @@ func TestUnitMapper(t *testing.T) {
 	ctx := context.Background()
 
 	Convey("When search requested with valid query", t, func() {
-		req := httptest.NewRequest("GET", "/search?q=housing&limit=1&offset=10&filter=article,filter2&sortBy=relevance", nil)
+		req := httptest.NewRequest("GET", "/search?q=housing&limit=1&offset=10&filter=article,filter2&sort=relevance", nil)
 		query := req.URL.Query()
 
 		Convey("convert mock response to client model", func() {


### PR DESCRIPTION
### What

**Describe what you have changed and why.**
- Change the sort query name from `sortBy` to `sort` to follow `dp-search-query` naming convention

### How to review

**Describe the steps required to test the changes.**
- Check if it looks good

### Who can review

**Describe who worked on the changes, so that other people can review.**
Anyone - Justin made the changes