### PR TITLE
Feature/rename search

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 ONS Digital
+Copyright (c) 2020 - 2021 ONS Digital
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ See [CONTRIBUTING](CONTRIBUTING.md) for details.
 
 ### License
 
-Copyright © 2020, Office for National Statistics (https://www.ons.gov.uk)
+Copyright © 2020 - 2021, Office for National Statistics (https://www.ons.gov.uk)
 
 Released under MIT license, see [LICENSE](LICENSE.md) for details.
 

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 
+    tag: 1.15.7
 
 inputs:
   - name: dp-frontend-search-controller

--- a/config/config.go
+++ b/config/config.go
@@ -10,7 +10,7 @@ import (
 type Config struct {
 	BindAddr                   string        `envconfig:"BIND_ADDR"`
 	RendererURL                string        `envconfig:"RENDERER_URL"`
-	SearchQueryURL             string        `envconfig:"SEARCH_QUERY_URL"`
+	SearchAPIURL               string        `envconfig:"SEARCH_API_URL"`
 	GracefulShutdownTimeout    time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
 	HealthCheckInterval        time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
 	HealthCheckCriticalTimeout time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
@@ -28,7 +28,7 @@ func Get() (*Config, error) {
 	cfg := &Config{
 		BindAddr:                   ":25000",
 		RendererURL:                "http://localhost:20010",
-		SearchQueryURL:				"http://localhost:23900",
+		SearchAPIURL:               "http://localhost:23900",
 		GracefulShutdownTimeout:    5 * time.Second,
 		HealthCheckInterval:        30 * time.Second,
 		HealthCheckCriticalTimeout: 90 * time.Second,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -20,7 +20,7 @@ func TestConfig(t *testing.T) {
 			Convey("Then the values should be set to the expected defaults", func() {
 				So(cfg.BindAddr, ShouldEqual, ":25000")
 				So(cfg.RendererURL, ShouldEqual, "http://localhost:20010")
-				So(cfg.SearchQueryURL, ShouldEqual, "http://localhost:23900")
+				So(cfg.SearchAPIURL, ShouldEqual, "http://localhost:23900")
 				So(cfg.GracefulShutdownTimeout, ShouldEqual, 5*time.Second)
 				So(cfg.HealthCheckInterval, ShouldEqual, 30*time.Second)
 				So(cfg.HealthCheckCriticalTimeout, ShouldEqual, 90*time.Second)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ONSdigital/dp-frontend-search-controller
 
-go 1.14
+go 1.15
 
 require (
 	github.com/ONSdigital/dp-api-clients-go v1.32.10

--- a/main.go
+++ b/main.go
@@ -47,7 +47,7 @@ func main() {
 
 	clients := routes.Clients{
 		Renderer: renderer.New(cfg.RendererURL),
-		Search:   search.NewClient(cfg.SearchQueryURL),
+		Search:   search.NewClient(cfg.SearchAPIURL),
 	}
 
 	healthcheck := health.New(versionInfo, cfg.HealthCheckCriticalTimeout, cfg.HealthCheckInterval)


### PR DESCRIPTION
### What

- renames `SearchQueryURL` to `SearchAPIURL`, and the env variable to `SEARCH_API_URL` (matching the changes in [this PR](https://github.com/ONSdigital/dp-configs/pull/260))
- updates and tags Go version
- updates license

### How to review

- run tests
- check Go version updated throughout

### Who can review

Anyone but Justin 😆 
