### PR TITLE
Fix pagination showing more than default max results

### DIFF
--- a/data/pagination.go
+++ b/data/pagination.go
@@ -102,7 +102,10 @@ func getOffset(ctx context.Context, cfg *config.Config, page int, limit int) (of
 }
 
 // GetTotalPages gets the total pages of the search results
-func GetTotalPages(limit int, count int) int {
+func GetTotalPages(cfg *config.Config, limit, count int) int {
+	if count > cfg.DefaultMaximumSearchResults {
+		return cfg.DefaultMaximumSearchResults / limit
+	}
 	return (count + limit - 1) / limit
 }
 

--- a/data/pagination_test.go
+++ b/data/pagination_test.go
@@ -294,13 +294,14 @@ func TestUnitGetOffsetFailure(t *testing.T) {
 
 func TestUnitGetTotalPagesSuccess(t *testing.T) {
 	t.Parallel()
+	cfg, _ := config.Get()
 
 	Convey("Given valid limit and/or count", t, func() {
 		limit := 10
 		count := 100
 
 		Convey("When GetTotalPages is called", func() {
-			totalPages := GetTotalPages(limit, count)
+			totalPages := GetTotalPages(cfg, limit, count)
 
 			Convey("Then successfully get total pages", func() {
 				So(totalPages, ShouldEqual, 10)

--- a/data/pagination_test.go
+++ b/data/pagination_test.go
@@ -307,6 +307,13 @@ func TestUnitGetTotalPagesSuccess(t *testing.T) {
 				So(totalPages, ShouldEqual, 10)
 			})
 		})
+
+		Convey("When results count is greater than default max results GetTotalPages returns the max default", func() {
+			largerCount := cfg.DefaultMaximumSearchResults + 1
+			totalPages := GetTotalPages(cfg, limit, largerCount)
+			expectedNumberOfPages := cfg.DefaultMaximumSearchResults / limit
+			So(totalPages, ShouldEqual, expectedNumberOfPages)
+		})
 	})
 }
 

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -73,7 +73,7 @@ func read(w http.ResponseWriter, req *http.Request, cfg *config.Config, rendC Re
 
 	// TO-DO: Until API handles aggregration on datatypes (e.g. bulletins, article), we need to make a second request
 
-	err = validateCurrentPage(ctx, validatedQueryParams, searchResp.Count)
+	err = validateCurrentPage(ctx, cfg, validatedQueryParams, searchResp.Count)
 	if err != nil {
 		log.Event(ctx, "unable to validate current page", log.Error(err), log.ERROR)
 		setStatusCode(w, req, err)
@@ -96,10 +96,10 @@ func read(w http.ResponseWriter, req *http.Request, cfg *config.Config, rendC Re
 }
 
 // validateCurrentPage checks if the current page exceeds the total pages which is a bad request
-func validateCurrentPage(ctx context.Context, validatedQueryParams data.SearchURLParams, resultsCount int) error {
+func validateCurrentPage(ctx context.Context, cfg *config.Config, validatedQueryParams data.SearchURLParams, resultsCount int) error {
 
 	if resultsCount > 0 {
-		totalPages := data.GetTotalPages(validatedQueryParams.Limit, resultsCount)
+		totalPages := data.GetTotalPages(cfg, validatedQueryParams.Limit, resultsCount)
 
 		if validatedQueryParams.CurrentPage > totalPages {
 			err := errs.ErrPageExceedsTotalPages

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -286,6 +286,7 @@ func TestUnitValidateCurrentPageSuccess(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
+	cfg, _ := config.Get()
 
 	Convey("Given number of search results is more than 0", t, func() {
 		resultsCount := 10
@@ -297,7 +298,7 @@ func TestUnitValidateCurrentPageSuccess(t *testing.T) {
 			}
 
 			Convey("When validateCurrentPage is called", func() {
-				err := validateCurrentPage(ctx, validatedQueryParams, resultsCount)
+				err := validateCurrentPage(ctx, cfg, validatedQueryParams, resultsCount)
 
 				Convey("Then return no error", func() {
 					So(err, ShouldBeNil)
@@ -316,7 +317,7 @@ func TestUnitValidateCurrentPageSuccess(t *testing.T) {
 			}
 
 			Convey("When validateCurrentPage is called", func() {
-				err := validateCurrentPage(ctx, validatedQueryParams, resultsCount)
+				err := validateCurrentPage(ctx, cfg, validatedQueryParams, resultsCount)
 
 				Convey("Then return no error", func() {
 					So(err, ShouldBeNil)
@@ -330,6 +331,7 @@ func TestUnitValidateCurrentPageFailure(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
+	cfg, _ := config.Get()
 
 	Convey("Given current page exceeds total pages", t, func() {
 		validatedQueryParams := data.SearchURLParams{
@@ -341,7 +343,7 @@ func TestUnitValidateCurrentPageFailure(t *testing.T) {
 			resultsCount := 20
 
 			Convey("When validateCurrentPage is called", func() {
-				err := validateCurrentPage(ctx, validatedQueryParams, resultsCount)
+				err := validateCurrentPage(ctx, cfg, validatedQueryParams, resultsCount)
 
 				Convey("Then return no error", func() {
 					So(err, ShouldNotBeNil)

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -55,7 +55,7 @@ func mapPagination(cfg *config.Config, page *model.Page, validatedQueryParams da
 	page.Data.Pagination.LimitOptions = data.LimitOptions
 
 	page.Data.Pagination.CurrentPage = validatedQueryParams.CurrentPage
-	page.Data.Pagination.TotalPages = data.GetTotalPages(validatedQueryParams.Limit, respC.Count)
+	page.Data.Pagination.TotalPages = data.GetTotalPages(cfg, validatedQueryParams.Limit, respC.Count)
 	page.Data.Pagination.PagesToDisplay = data.GetPagesToDisplay(cfg, validatedQueryParams, page.Data.Pagination.TotalPages)
 }
 


### PR DESCRIPTION
### What

Fix pagination showing more than default max results

### How to review

While running new search you should no longer see pages and result beyond default max result currently set at 500. 
e.g if you have results at 10 per page you should only be able to get 50 pages no more, or if set at 50 per page then only 10 pages

### Who can review

Anyone
