### PR TITLE
remove extra main element

### DIFF
--- a/assets/templates/search.tmpl
+++ b/assets/templates/search.tmpl
@@ -1,16 +1,14 @@
 <div class="search search--results-page print--hide" id="searchBar">
     {{ template "partials/bar" . }}
 </div>
-<main id="main" role="main" tabindex="-1">
-    <div class="page-content border">
-        <div class="wrapper">
-            {{ template "partials/sort" . }}
-            {{ template "partials/filter" . }}
+<div class="page-content border">
+    <div class="wrapper">
+        {{ template "partials/sort" . }}
+        {{ template "partials/filter" . }}
             <section class="col col--md-34 col--lg-40 margin-left-md--1" aria-label="Search results">
                 {{ template "partials/department" . }}
                 {{ template "partials/results" . }}
                 {{ template "partials/pagination" . }}
             </section>
-        </div>
     </div>
-</main>
+</div>


### PR DESCRIPTION
### What

Extra `main` element was found on one of the new search pages. This is now removed. This has been checked with aXe and Lighthouse which shows there is no longer a duplicate `main` tag. 
<img width="1158" alt="Screenshot 2021-11-24 at 13 23 13" src="https://user-images.githubusercontent.com/16807393/143247468-e759ac86-a4ee-4ed9-b8e2-879bc8166834.png">

<img width="1161" alt="Screenshot 2021-11-24 at 13 28 50" src="https://user-images.githubusercontent.com/16807393/143247819-95565c0a-a364-4f1b-a267-4cd49934dded.png">



### How to review

On new search, inspect page and see that there is only one `main` element. 

### Who can review

Anyone but me. 
