### PR TITLE
add templating to id and for

### DIFF
--- a/assets/templates/partials/filter.tmpl
+++ b/assets/templates/partials/filter.tmpl
@@ -20,8 +20,8 @@
                                     <li class="filters__item">
                                         <div class="filters__field">
                                             {{ $id := (print "checkout-" $content.Type) }}
-                                            <input id=$id class="js-auto-submit__input" type="checkbox" name="filter" value={{ $content.Type }} {{ range $filter }}{{ if eq . $content.Type }}checked{{end}}{{end}}>
-                                            <label for=$id>
+                                            <input id={{ $id }} class="js-auto-submit__input" type="checkbox" name="filter" value={{ $content.Type }} {{ range $filter }}{{ if eq . $content.Type }}checked{{end}}{{end}}>
+                                            <label for={{ $id }}>
                                             {{ localise $content.LocaliseKeyName $lang 4 }} ({{ $content.Count }})
                                             </label>
                                         </div>

--- a/assets/templates/partials/filter.tmpl
+++ b/assets/templates/partials/filter.tmpl
@@ -20,8 +20,8 @@
                                     <li class="filters__item">
                                         <div class="filters__field">
                                             {{ $id := (print "checkout-" $content.Type) }}
-                                            <input id={{ $id }} class="js-auto-submit__input" type="checkbox" name="filter" value={{ $content.Type }} {{ range $filter }}{{ if eq . $content.Type }}checked{{end}}{{end}}>
-                                            <label for={{ $id }}>
+                                            <input id="{{ $id }}" class="js-auto-submit__input" type="checkbox" name="filter" value={{ $content.Type }} {{ range $filter }}{{ if eq . $content.Type }}checked{{end}}{{end}}>
+                                            <label for="{{ $id }}">
                                             {{ localise $content.LocaliseKeyName $lang 4 }} ({{ $content.Count }})
                                             </label>
                                         </div>


### PR DESCRIPTION
### What

Checkboxes had non-unique values so they could only select the first checkbox. Added templating to variables so that `id` and `for` values are unique. 

### How to review

On new search results page on the left under `Content types to show`, see that one can now choose multiple checkboxes. Inspect code and see that `id` and `for` should be the selected content type and not `$id`.  
![Screenshot 2021-11-25 at 08 50 48](https://user-images.githubusercontent.com/16807393/143409562-54e21390-72ba-479f-9b77-0ddb5f3fc42c.png)


### Who can review

Anyone but me. 
