### PR TITLE
Fix/show correct data type

### DIFF
--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -54,10 +54,12 @@ other = "Compendiwm"
 
 [TimeSeries]
 description = "Time series"
+one = "Cyfres amser"
 other = "Cyfres amser"
 
 [Datasets]
 description = "Datasets"
+one = "Set ddata"
 other = "Datasets"
 
 [Methodology]
@@ -71,10 +73,12 @@ one = "Dyddiad y datganiad"
 
 [UserRequestedData]
 description = "User requested data"
+one = "Data a gyrchwyd gan y defnyddiwr"
 other = "Data a gyrchwyd gan y defnyddiwr"
 
 [CorporateInformation]
 description = "Corporate Information"
+one = "Corporate Information"
 other = "Corporate Information"
 
 [And]

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -54,10 +54,12 @@ other = "Compendiums"
 
 [TimeSeries]
 description = "Time series"
+one = "Time series"
 other = "Time series"
 
 [Datasets]
 description = "Datasets"
+one = "Dataset"
 other = "Datasets"
 
 [Methodology]
@@ -75,6 +77,7 @@ other = "User requested data"
 
 [CorporateInformation]
 description = "Corporate Information"
+one = "Corporate Information"
 other = "Corporate Information"
 
 [And]

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -73,6 +73,7 @@ one = "Release date"
 
 [UserRequestedData]
 description = "User requested data"
+one = "User requested data"
 other = "User requested data"
 
 [CorporateInformation]

--- a/assets/templates/partials/results.tmpl
+++ b/assets/templates/partials/results.tmpl
@@ -28,11 +28,13 @@
                         {{ $type := .Type }}
                             {{ range $category := $response.Categories }}
                                 {{ range $content := $category.ContentTypes }}
-                                    {{ if eq $type $content.Type }}
-                                        {{ localise $content.LocaliseKeyName $lang 4 }}
+                                    {{ range $content.SubTypes }}
+                                        {{ if eq . $type }}
+                                            {{ localise $content.LocaliseKeyName $lang 4 }}
+                                        {{ end }}
                                     {{ end }}
-                                {{end}}
-                             {{end}}
+                                {{ end }}
+                             {{ end }}
                             |
                             {{ localise "ReleasedOn" $lang 1 }} {{dateFormat .Description.ReleaseDate}}
                         </p>

--- a/assets/templates/partials/results.tmpl
+++ b/assets/templates/partials/results.tmpl
@@ -2,6 +2,8 @@
 {{ $currentPage := .Data.Pagination.CurrentPage }}
 {{ $itemsPerPage := .Data.Pagination.Limit }}
 {{ $totalSearchPosition := multiply (subtract $currentPage 1) $itemsPerPage }}
+{{ $filter := .Data.Filter }}
+{{ $response := .Data.Response }}
 <div id="results" class="results">    
     {{ if ne .Data.Response.Count 0 }}
         <div class="search-results ">
@@ -23,7 +25,14 @@
                             </a>
                         </h3>
                         <p class="search-results__meta font-size--16">
-                            {{ .Type}}
+                        {{ $type := .Type }}
+                            {{ range $category := $response.Categories }}
+                                {{ range $content := $category.ContentTypes }}
+                                    {{ if eq $type $content.Type }}
+                                        {{ localise $content.LocaliseKeyName $lang 4 }}
+                                    {{ end }}
+                                {{end}}
+                             {{end}}
                             |
                             {{ localise "ReleasedOn" $lang 1 }} {{dateFormat .Description.ReleaseDate}}
                         </p>

--- a/assets/templates/partials/results.tmpl
+++ b/assets/templates/partials/results.tmpl
@@ -2,7 +2,6 @@
 {{ $currentPage := .Data.Pagination.CurrentPage }}
 {{ $itemsPerPage := .Data.Pagination.Limit }}
 {{ $totalSearchPosition := multiply (subtract $currentPage 1) $itemsPerPage }}
-{{ $filter := .Data.Filter }}
 {{ $response := .Data.Response }}
 <div id="results" class="results">    
     {{ if ne .Data.Response.Count 0 }}
@@ -30,7 +29,7 @@
                                 {{ range $content := $category.ContentTypes }}
                                     {{ range $content.SubTypes }}
                                         {{ if eq . $type }}
-                                            {{ localise $content.LocaliseKeyName $lang 4 }}
+                                            {{ localise $content.LocaliseKeyName $lang 1 }}
                                         {{ end }}
                                     {{ end }}
                                 {{ end }}

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -95,6 +95,7 @@ func mapResponseCategories(page *model.SearchPage, categories []data.Category) {
 				Type:            contentType.Type,
 				Count:           contentType.Count,
 				LocaliseKeyName: contentType.LocaliseKeyName,
+				SubTypes:		contentType.SubTypes,
 			})
 		}
 

--- a/model/search.go
+++ b/model/search.go
@@ -53,7 +53,7 @@ type ContentType struct {
 	Type            string 		`json:"type"`
 	Count           int    		`json:"count"`
 	LocaliseKeyName string 		`json:"localise_key"`
-	SubTypes		[]string 	`json:"sub_types"`
+	SubTypes        []string    `json:"sub_types"`
 }
 
 // ContentItem represents each search result

--- a/model/search.go
+++ b/model/search.go
@@ -50,10 +50,10 @@ type Category struct {
 
 // ContentType represents the type of the search results and the number of results for each type
 type ContentType struct {
-	Type            string 		`json:"type"`
-	Count           int    		`json:"count"`
-	LocaliseKeyName string 		`json:"localise_key"`
-	SubTypes        []string    `json:"sub_types"`
+	Type            string		`json:"type"`
+	Count           int		`json:"count"`
+	LocaliseKeyName string		`json:"localise_key"`
+	SubTypes        []string	`json:"sub_types"`
 }
 
 // ContentItem represents each search result

--- a/model/search.go
+++ b/model/search.go
@@ -50,9 +50,10 @@ type Category struct {
 
 // ContentType represents the type of the search results and the number of results for each type
 type ContentType struct {
-	Type            string `json:"type"`
-	Count           int    `json:"count"`
-	LocaliseKeyName string `json:"localise_key"`
+	Type            string 		`json:"type"`
+	Count           int    		`json:"count"`
+	LocaliseKeyName string 		`json:"localise_key"`
+	SubTypes		[]string 	`json:"sub_types"`
 }
 
 // ContentItem represents each search result


### PR DESCRIPTION
### What

Search results were sometimes returning data `subTypes` (eg, `article_download`) which did not match the selected filter option. Search results now return the correct data type that matches the selected filter option. The data type showing is the singular instead of the plural version of the selected filter option. 

### How to review

Go to new search. Search for something (eg, "economics"), select filter options. See that singular word appears that matches the filter option.

### Who can review

Anyone but me. 
