### PR TITLE
update reference to renderer library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ONSdigital/dp-cookies v0.3.3
 	github.com/ONSdigital/dp-healthcheck v1.1.0
 	github.com/ONSdigital/dp-net v1.2.0
-	github.com/ONSdigital/dp-renderer v1.9.1
+	github.com/ONSdigital/dp-renderer v1.9.4
 	github.com/ONSdigital/log.go/v2 v2.0.9
 	github.com/cucumber/godog v0.11.0
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/ONSdigital/dp-net v1.2.0 h1:gP9pBt/J8gktYeKsb7hq6uOC2xx1tfvTorUBNXp6p
 github.com/ONSdigital/dp-net v1.2.0/go.mod h1:NinlaqcsPbIR+X7j5PXCl3UI5G2zCL041SDF6WIiiO4=
 github.com/ONSdigital/dp-renderer v1.9.1 h1:g0w6JwXanrefSJ8eB3R08Zw1r0/PUYfqXQLz6fPY1WA=
 github.com/ONSdigital/dp-renderer v1.9.1/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
+github.com/ONSdigital/dp-renderer v1.9.4 h1:A3zyIVRndOZYUZiHw8ZJY8xSaV9iALsPmmd3iQe7Uxg=
+github.com/ONSdigital/dp-renderer v1.9.4/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
 github.com/ONSdigital/log.go v1.0.0/go.mod h1:UnGu9Q14gNC+kz0DOkdnLYGoqugCvnokHBRBxFRpVoQ=
 github.com/ONSdigital/log.go v1.0.1-0.20200805084515-ee61165ea36a/go.mod h1:dDnQATFXCBOknvj6ZQuKfmDhbOWf3e8mtV+dPEfWJqs=


### PR DESCRIPTION
### What

Update reference to dp-renderer library to latest version. 

### How to review

See that url ending is `/feedback` and not does not contain at the end `?service=cmd`. Page still populates under "What's it to do with?". Radio with "This new service (customising data by applying filters)" is no longer an option.  
<img width="1054" alt="Screenshot 2021-12-14 at 09 26 48" src="https://user-images.githubusercontent.com/16807393/145971637-fa9d7f20-ec20-48ed-987e-3feee36ec6a3.png">
<img width="941" alt="Screenshot 2021-12-14 at 09 27 18" src="https://user-images.githubusercontent.com/16807393/145971670-bc7b6bac-faa7-445b-8004-71710f2636b0.png">

### Who can review

Anyone but me. 
