### PR TITLE
update to newest release of dp-renderer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ONSdigital/dp-cookies v0.3.3
 	github.com/ONSdigital/dp-healthcheck v1.1.0
 	github.com/ONSdigital/dp-net v1.2.0
-	github.com/ONSdigital/dp-renderer v1.9.4
+	github.com/ONSdigital/dp-renderer v1.9.5
 	github.com/ONSdigital/log.go/v2 v2.0.9
 	github.com/cucumber/godog v0.11.0
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/ONSdigital/dp-renderer v1.9.1 h1:g0w6JwXanrefSJ8eB3R08Zw1r0/PUYfqXQLz
 github.com/ONSdigital/dp-renderer v1.9.1/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
 github.com/ONSdigital/dp-renderer v1.9.4 h1:A3zyIVRndOZYUZiHw8ZJY8xSaV9iALsPmmd3iQe7Uxg=
 github.com/ONSdigital/dp-renderer v1.9.4/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
+github.com/ONSdigital/dp-renderer v1.9.5 h1:ssNbHMDiqKgOkYqunLa7Sg+bM4UZ3H51c7Hh5ll21DI=
+github.com/ONSdigital/dp-renderer v1.9.5/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
 github.com/ONSdigital/log.go v1.0.0/go.mod h1:UnGu9Q14gNC+kz0DOkdnLYGoqugCvnokHBRBxFRpVoQ=
 github.com/ONSdigital/log.go v1.0.1-0.20200805084515-ee61165ea36a/go.mod h1:dDnQATFXCBOknvj6ZQuKfmDhbOWf3e8mtV+dPEfWJqs=


### PR DESCRIPTION
### What

Update to newest release of `dp-renderer`

### How to review

See that dp-renderer version matches the lastest release (1.9.5) of the [dp-renderer library](https://github.com/ONSdigital/dp-renderer/releases/tag/v1.9.5) 

### Who can review

Anyone but me
