### PR TITLE
added logic for filter open style

### DIFF
--- a/assets/templates/partials/filter.tmpl
+++ b/assets/templates/partials/filter.tmpl
@@ -17,10 +17,10 @@
                 {{ range $index, $category := $response.Categories }}
                     <div class="ons-checkboxes__items">
                             <span class="ons-checkboxes__item ons-checkboxes__item--no-border">
-                                <span class="ons-checkbox ons-checkbox--no-border">
+                                <span class="ons-checkbox ons-checkbox--no-border category-filter">
                                     <input type="checkbox" id="group-{{ $index }}"
-                                           class="js-auto-submit__input ons-checkbox__input ons-js-checkbox ons-js-select-all-children"
-                                           value="{{ $category }}" aria-controls="group-{{ $index }}-other-wrap"
+                                           class="js-auto-submit__input ons-checkbox__input ons-js-checkbox"
+                                           value="{{ $category }}" categoryChildren="{{ range $contentIndex, $content := $category.ContentTypes }}{{$content.Type}}{{","}}{{end}}" aria-controls="group-{{ $index }}-other-wrap"
                                            aria-haspopup="true"
                                               {{ range $content := $category.ContentTypes}}
                                                   {{if stringArrayContains $content.Type $filter }}
@@ -60,11 +60,9 @@
                     </div>
                 {{ end }}
             </fieldset>
-            <noscript>
-                <button type="submit"
-                        class="btn btn--primary btn--thick margin-top-sm--2 margin-top-md--2 js-submit-button">Filter
-                </button>
-            </noscript>
+            <button type="submit"
+                    class="btn btn--primary btn--thick margin-top-sm--2 margin-top-md--2 js-submit-button">Filter
+            </button>
         </div>
     </div>
     <div class="tiles__item tiles__item--nav-type flush-col hide--sm print--hide">

--- a/assets/templates/partials/filter.tmpl
+++ b/assets/templates/partials/filter.tmpl
@@ -60,9 +60,11 @@
                     </div>
                 {{ end }}
             </fieldset>
-            <button type="submit"
-                    class="btn btn--primary btn--thick margin-top-sm--2 margin-top-md--2 js-submit-button">Filter
-            </button>
+            <noscript>
+                <button type="submit"
+                        class="btn btn--primary btn--thick margin-top-sm--2 margin-top-md--2 js-submit-button">Filter
+                </button>
+            </noscript>
         </div>
     </div>
     <div class="tiles__item tiles__item--nav-type flush-col hide--sm print--hide">

--- a/assets/templates/partials/filter.tmpl
+++ b/assets/templates/partials/filter.tmpl
@@ -32,7 +32,7 @@
                                            id="group-{{ $index }}-label">
                                         {{ localise $category.LocaliseKeyName $lang 4 }} ({{ $category.Count }})
                                     </label>
-                                    <span class="ons-checkbox__other ons-checkbox__other--open" id="group-{{ $index }}-other-wrap">
+                                    <span class="ons-checkbox__other {{ range $content := $category.ContentTypes }}{{ range $filter }}{{ if eq . $content.Type }}ons-checkbox__other--open{{end}}{{end}}{{end}}" id="group-{{ $index }}-other-wrap">
                                         <fieldset class="ons-fieldset ons-js-other-fieldset">
                                             {{ range $contentIndex, $content := $category.ContentTypes }}
                                                 <div class="ons-checkboxes__items">

--- a/assets/templates/partials/results.tmpl
+++ b/assets/templates/partials/results.tmpl
@@ -3,7 +3,7 @@
 {{ $itemsPerPage := .Data.Pagination.Limit }}
 {{ $totalSearchPosition := multiply (subtract $currentPage 1) $itemsPerPage }}
 {{ $response := .Data.Response }}
-<div id="results" class="search__results">
+<div id="results">
     <h2>
         {{ if ne .Data.Response.Count 0 }}
             <ul class="list--neutral flush">

--- a/config/config.go
+++ b/config/config.go
@@ -37,7 +37,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9002/dist/assets"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/00967c3"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/9fc59f8"
 	}
 	return cfg, nil
 }


### PR DESCRIPTION
### What

- Added styling for the search filter
- Added additional logic around the categories to help with how the filters behave
- update the commit ref for the dp-deign-system
- added additional

### How to review

- ensure you have the latest `dp-design-system`
- pull this branch and run
- do a search
- filter the search on the left
- the filters should appear closed until you have selected a category type
- when the page reloads from the filter, the filter should remain selected and open where appropriate.
- this should also work if you do a filter and then manually refresh the page


### Who can review

Anyone
