### PR TITLE
Fix/current page datalayer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ONSdigital/dp-cookies v0.3.3
 	github.com/ONSdigital/dp-healthcheck v1.1.0
 	github.com/ONSdigital/dp-net v1.2.0
-	github.com/ONSdigital/dp-renderer v1.10.6
+	github.com/ONSdigital/dp-renderer v1.10.7
 	github.com/ONSdigital/log.go/v2 v2.0.9
 	github.com/cucumber/godog v0.11.0
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ github.com/ONSdigital/dp-renderer v1.10.5 h1:1/xSOs11ktfYjBO45xhicH7/Foaaca9pJvk
 github.com/ONSdigital/dp-renderer v1.10.5/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
 github.com/ONSdigital/dp-renderer v1.10.6 h1:Mh/WgoyMl2ITI7MaI89QqAJ3tibb0syoiiDKqFLUo8s=
 github.com/ONSdigital/dp-renderer v1.10.6/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
+github.com/ONSdigital/dp-renderer v1.10.7 h1:x/6N0LJ61FJO4io/Woe/BxK2PmnwmJFWCQ86BbSgu+k=
+github.com/ONSdigital/dp-renderer v1.10.7/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
 github.com/ONSdigital/log.go v1.0.0/go.mod h1:UnGu9Q14gNC+kz0DOkdnLYGoqugCvnokHBRBxFRpVoQ=
 github.com/ONSdigital/log.go v1.0.1-0.20200805084515-ee61165ea36a/go.mod h1:dDnQATFXCBOknvj6ZQuKfmDhbOWf3e8mtV+dPEfWJqs=

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -28,6 +28,7 @@ func CreateSearchPage(cfg *config.Config, req *http.Request, basePage coreModel.
 	page.SearchDisabled = false
 	page.URI = req.URL.Path
 	page.PatternLibraryAssetsPath = cfg.PatternLibraryAssetsPath
+	page.Pagination.CurrentPage = validatedQueryParams.CurrentPage
 
 	mapQuery(cfg, &page, validatedQueryParams, categories, respC)
 


### PR DESCRIPTION
### What

Update reference to renderer library and map current page to new search page. 

### How to review

Sense check. Or pull this branch, run the `dp-search-api` and `dp-frontend-search-controller` with `make debug`, set `SearchRoutesEnabled` to `true` in the `dp-frontend-router`. Enter a search term in the search bar. Once the results page loads, in the console run `console.log(window.dataLayer)`, `resultsPage` should appear with the current search page as the value. 
<img width="1222" alt="Screenshot 2022-01-14 at 12 14 51" src="https://user-images.githubusercontent.com/16807393/149519018-4e816be0-404f-4c03-824f-af4a12689328.png">


### Who can review

Anyone but me
