### PR TITLE
update type field and move loop logic to controller

### DIFF
--- a/assets/templates/partials/filter.tmpl
+++ b/assets/templates/partials/filter.tmpl
@@ -23,7 +23,7 @@
                                            value="{{ $category }}" aria-controls="group-{{ $index }}-other-wrap"
                                            aria-haspopup="true"
                                               {{ range $content := $category.ContentTypes}}
-                                                  {{if stringArrayContains $content.Type $filter }}
+                                                  {{if stringArrayContains $content.Group $filter }}
                                                       checked
                                                   {{end}}
                                               {{end}}
@@ -38,11 +38,11 @@
                                                 <div class="ons-checkboxes__items">
                                                 <span class="ons-checkboxes__item ons-checkboxes__item--no-border">
                                                     <span class="ons-checkbox ons-checkbox--no-border child-filter">
-                                                        {{ $id := (print $content.Type) }}
+                                                        {{ $id := (print $content.Group) }}
                                                         <input id="{{ $id }}"
                                                                class="js-auto-submit__input ons-checkbox__input ons-js-checkbox"
                                                                type="checkbox" name="filter"
-                                                               {{ range $filter }}{{ if eq . $content.Type }}checked{{end}}{{end}}
+                                                               {{ range $filter }}{{ if eq . $content.Group }}checked{{end}}{{end}}
                                                                value="{{ $id }}"
                                                         />
                                                         <label class="ons-checkbox__label" for="{{ $id }}"

--- a/assets/templates/partials/results.tmpl
+++ b/assets/templates/partials/results.tmpl
@@ -24,16 +24,7 @@
                         </a>
                     </h3>
                     <p class="search-results__meta font-size--16">
-                        {{ $type := .Type }}
-                        {{ range $category := $response.Categories }}
-                            {{ range $content := $category.ContentTypes }}
-                                {{ range $content.Types }}
-                                    {{ if eq . $type }}
-                                        {{ localise $content.LocaliseKeyName $lang 1 }}
-                                    {{ end }}
-                                {{ end }}
-                            {{ end }}
-                        {{ end }}
+                        {{ localise .Type.LocaliseKeyName $lang 1 }}
                         |
                         {{ localise "ReleasedOn" $lang 1 }} {{dateFormat .Description.ReleaseDate}}
                     </p>

--- a/assets/templates/partials/results.tmpl
+++ b/assets/templates/partials/results.tmpl
@@ -27,7 +27,7 @@
                         {{ $type := .Type }}
                         {{ range $category := $response.Categories }}
                             {{ range $content := $category.ContentTypes }}
-                                {{ range $content.SubTypes }}
+                                {{ range $content.Types }}
                                     {{ if eq . $type }}
                                         {{ localise $content.LocaliseKeyName $lang 1 }}
                                     {{ end }}

--- a/data/filter.go
+++ b/data/filter.go
@@ -26,8 +26,8 @@ type Category struct {
 type ContentType struct {
 	LocaliseKeyName string   `json:"localise_key"`
 	Count           int      `json:"count"`
-	Type            string   `json:"type"`
-	SubTypes        []string `json:"sub_types"`
+	Group           string   `json:"group"`
+	Types           []string `json:"types"`
 }
 
 var defaultContentTypes = "article," +
@@ -76,69 +76,69 @@ var (
 	// Bulletin - Search information specific for statistical bulletins
 	Bulletin = ContentType{
 		LocaliseKeyName: "StatisticalBulletin",
-		Type:            "bulletin",
-		SubTypes:        []string{"bulletin"},
+		Group:           "bulletin",
+		Types:           []string{"bulletin"},
 	}
 
 	// Article - Search information specific for articles
 	Article = ContentType{
 		LocaliseKeyName: "Article",
-		Type:            "article",
-		SubTypes:        []string{"article", "article_download"},
+		Group:           "article",
+		Types:           []string{"article", "article_download"},
 	}
 
 	// Compendium - Search information specific for compendium
 	Compendium = ContentType{
 		LocaliseKeyName: "Compendium",
-		Type:            "compendia",
-		SubTypes:        []string{"compendium_landing_page"},
+		Group:           "compendia",
+		Types:           []string{"compendium_landing_page"},
 	}
 
 	// TimeSeries - Search information specific for time series
 	TimeSeries = ContentType{
 		LocaliseKeyName: "TimeSeries",
-		Type:            "time_series",
-		SubTypes:        []string{"timeseries"},
+		Group:           "time_series",
+		Types:           []string{"timeseries"},
 	}
 
 	// Datasets - Search information specific for datasets
 	Datasets = ContentType{
 		LocaliseKeyName: "Datasets",
-		Type:            "datasets",
-		SubTypes:        []string{"dataset_landing_page", "reference_tables"},
+		Group:           "datasets",
+		Types:           []string{"dataset_landing_page", "reference_tables"},
 	}
 
 	// UserRequestedData - Search information specific for user requested data
 	UserRequestedData = ContentType{
 		LocaliseKeyName: "UserRequestedData",
-		Type:            "user_requested_data",
-		SubTypes:        []string{"static_adhoc"},
+		Group:           "user_requested_data",
+		Types:           []string{"static_adhoc"},
 	}
 
 	// Methodology - Search information specific for methodologies
 	Methodology = ContentType{
 		LocaliseKeyName: "Methodology",
-		Type:            "methodology",
-		SubTypes:        []string{"static_methodology", "static_methodology_download", "static_qmi"},
+		Group:           "methodology",
+		Types:           []string{"static_methodology", "static_methodology_download", "static_qmi"},
 	}
 
 	// CorporateInformation - Search information specific for corporate information
 	CorporateInformation = ContentType{
 		LocaliseKeyName: "CorporateInformation",
-		Type:            "corporate_information",
-		SubTypes:        []string{"static_foi", "static_page", "static_landing_page", "static_article"},
+		Group:           "corporate_information",
+		Types:           []string{"static_foi", "static_page", "static_landing_page", "static_article"},
 	}
 
 	// filterOptions contains all the possible filter available on the search page
 	filterOptions = map[string]ContentType{
-		Article.Type:              Article,
-		Bulletin.Type:             Bulletin,
-		Compendium.Type:           Compendium,
-		CorporateInformation.Type: CorporateInformation,
-		Datasets.Type:             Datasets,
-		Methodology.Type:          Methodology,
-		TimeSeries.Type:           TimeSeries,
-		UserRequestedData.Type:    UserRequestedData,
+		Article.Group:              Article,
+		Bulletin.Group:             Bulletin,
+		Compendium.Group:           Compendium,
+		CorporateInformation.Group: CorporateInformation,
+		Datasets.Group:             Datasets,
+		Methodology.Group:          Methodology,
+		TimeSeries.Group:           TimeSeries,
+		UserRequestedData.Group:    UserRequestedData,
 	}
 )
 
@@ -164,7 +164,7 @@ func reviewFilters(ctx context.Context, urlQuery url.Values, validatedQueryParam
 			return err
 		}
 
-		validatedQueryParams.Filter.Query = append(validatedQueryParams.Filter.Query, filter.Type)
+		validatedQueryParams.Filter.Query = append(validatedQueryParams.Filter.Query, filter.Group)
 		validatedQueryParams.Filter.LocaliseKeyName = append(validatedQueryParams.Filter.LocaliseKeyName, filter.LocaliseKeyName)
 	}
 
@@ -183,8 +183,8 @@ func GetCategories() []Category {
 
 		// To get a different reference of SubTypes - deep copy
 		for j := range category.ContentTypes {
-			categories[i].ContentTypes[j].SubTypes = []string{}
-			categories[i].ContentTypes[j].SubTypes = append(categories[i].ContentTypes[j].SubTypes, Categories[i].ContentTypes[j].SubTypes...)
+			categories[i].ContentTypes[j].Types = []string{}
+			categories[i].ContentTypes[j].Types = append(categories[i].ContentTypes[j].Types, Categories[i].ContentTypes[j].Types...)
 		}
 	}
 
@@ -210,7 +210,7 @@ func getSubFilters(filters []string) []string {
 
 	for _, filter := range filters {
 		subFilter := filterOptions[filter]
-		subFilters = append(subFilters, subFilter.SubTypes...)
+		subFilters = append(subFilters, subFilter.Types...)
 	}
 
 	return subFilters

--- a/data/filter.go
+++ b/data/filter.go
@@ -125,10 +125,11 @@ var (
 		Types:           []string{"static_foi", "static_page", "static_landing_page", "static_article"},
 	}
 
+	// ProductPage - Search information specific for product pages
 	ProductPage = ContentType{
 		LocaliseKeyName: "ProductPage",
-		Type:            "product_page",
-		SubTypes:        []string{"product_page"},
+		Group:           "product_page",
+		Types:           []string{"product_page"},
 	}
 
 	// filterOptions contains all the possible filter available on the search page

--- a/data/filter.go
+++ b/data/filter.go
@@ -79,8 +79,8 @@ var (
 	// Article - Search information specific for articles
 	Article = ContentType{
 		LocaliseKeyName: "Article",
-		Group:           "article",                               //Type
-		Types:           []string{"article", "article_download"}, //SubType
+		Group:           "article",
+		Types:           []string{"article", "article_download"},
 	}
 
 	// Compendium - Search information specific for compendium
@@ -101,7 +101,7 @@ var (
 	Datasets = ContentType{
 		LocaliseKeyName: "Datasets",
 		Group:           "datasets",
-		Types:           []string{"dataset_landing_page", "reference_tables"},
+		Types:           []string{"dataset_landing_page", "timeseries_dataset"},
 	}
 
 	// UserRequestedData - Search information specific for user requested data

--- a/data/filter.go
+++ b/data/filter.go
@@ -83,8 +83,8 @@ var (
 	// Article - Search information specific for articles
 	Article = ContentType{
 		LocaliseKeyName: "Article",
-		Group:           "article",
-		Types:           []string{"article", "article_download"},
+		Group:           "article",                               //Type
+		Types:           []string{"article", "article_download"}, //SubType
 	}
 
 	// Compendium - Search information specific for compendium
@@ -214,4 +214,16 @@ func getSubFilters(filters []string) []string {
 	}
 
 	return subFilters
+}
+
+// GetGroupLocaliseKey gets the localise key of the group type of the search result to be displayed
+func GetGroupLocaliseKey(resultType string) string {
+	for _, filterOption := range filterOptions {
+		for _, optionType := range filterOption.Types {
+			if resultType == optionType {
+				return filterOption.LocaliseKeyName
+			}
+		}
+	}
+	return ""
 }

--- a/data/filter_test.go
+++ b/data/filter_test.go
@@ -288,3 +288,31 @@ func TestUnitGetSubFiltersSuccess(t *testing.T) {
 		})
 	})
 }
+
+func TestUnitGetGroupLocaliseKey(t *testing.T) {
+	t.Parallel()
+
+	Convey("Given the type of the search result", t, func() {
+		searchType := "static_methodology"
+
+		Convey("When getSubFilters is called", func() {
+			groupLocaliseKey := GetGroupLocaliseKey(searchType)
+
+			Convey("Then the localise key of the group type should be returned", func() {
+				So(groupLocaliseKey, ShouldEqual, "Methodology")
+			})
+		})
+	})
+
+	Convey("Given an unknown type of the search result", t, func() {
+		searchType := "unknown"
+
+		Convey("When getSubFilters is called", func() {
+			groupLocaliseKey := GetGroupLocaliseKey(searchType)
+
+			Convey("Then an empty localise key should be returned", func() {
+				So(groupLocaliseKey, ShouldEqual, "")
+			})
+		})
+	})
+}

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -134,7 +134,7 @@ func setCountToCategories(ctx context.Context, countResp searchCli.Response, cat
 	categoryLoop:
 		for i, category := range categories {
 			for j, contentType := range category.ContentTypes {
-				for _, subType := range contentType.SubTypes {
+				for _, subType := range contentType.Types {
 					if responseType.Type == subType {
 						categories[i].Count += responseType.Count
 						categories[i].ContentTypes[j].Count += responseType.Count

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -93,10 +93,10 @@ func mapResponseCategories(page *model.SearchPage, categories []data.Category) {
 
 		for _, contentType := range category.ContentTypes {
 			pageContentType = append(pageContentType, model.ContentType{
-				Type:            contentType.Type,
+				Group:           contentType.Group,
 				Count:           contentType.Count,
 				LocaliseKeyName: contentType.LocaliseKeyName,
-				SubTypes:        contentType.SubTypes,
+				Types:           contentType.Types,
 			})
 		}
 

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -120,7 +120,8 @@ func mapResponseItems(page *model.SearchPage, respC searchC.Response) {
 
 		mapItemHighlight(&item, itemC)
 
-		item.Type = itemC.Type
+		item.Type.Type = itemC.Type
+		item.Type.LocaliseKeyName = data.GetGroupLocaliseKey(itemC.Type)
 
 		item.URI = itemC.URI
 

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -103,7 +103,8 @@ func TestUnitCreateSearchPageSuccess(t *testing.T) {
 				So(sp.Data.Response.Items[0].Description.Summary, ShouldEqual, "Test Summary")
 				So(sp.Data.Response.Items[0].Description.Title, ShouldEqual, "Title Title")
 
-				So(sp.Data.Response.Items[0].Type, ShouldEqual, "article")
+				So(sp.Data.Response.Items[0].Type.Type, ShouldEqual, "article")
+				So(sp.Data.Response.Items[0].Type.LocaliseKeyName, ShouldEqual, "Article")
 				So(sp.Data.Response.Items[0].URI, ShouldEqual, "/uri1/housing/articles/uri2/2015-02-17")
 
 				testMatchesDescSummary := *sp.Data.Response.Items[0].Matches.Description.Summary

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -81,11 +81,11 @@ func TestUnitCreateSearchPageSuccess(t *testing.T) {
 				So(sp.Data.Response.Categories[0].LocaliseKeyName, ShouldEqual, "Publication")
 				So(sp.Data.Response.Categories[0].ContentTypes, ShouldHaveLength, 3)
 
-				So(sp.Data.Response.Categories[0].ContentTypes[0].Type, ShouldEqual, "bulletin")
+				So(sp.Data.Response.Categories[0].ContentTypes[0].Group, ShouldEqual, "bulletin")
 				So(sp.Data.Response.Categories[0].ContentTypes[0].Count, ShouldEqual, 0)
 				So(sp.Data.Response.Categories[0].ContentTypes[0].LocaliseKeyName, ShouldEqual, "StatisticalBulletin")
 
-				So(sp.Data.Response.Categories[0].ContentTypes[1].Type, ShouldEqual, "article")
+				So(sp.Data.Response.Categories[0].ContentTypes[1].Group, ShouldEqual, "article")
 				So(sp.Data.Response.Categories[0].ContentTypes[1].Count, ShouldEqual, 1)
 				So(sp.Data.Response.Categories[0].ContentTypes[1].LocaliseKeyName, ShouldEqual, "Article")
 

--- a/model/search.go
+++ b/model/search.go
@@ -50,10 +50,10 @@ type Category struct {
 
 // ContentType represents the type of the search results and the number of results for each type
 type ContentType struct {
-	Type            string		`json:"type"`
-	Count           int		`json:"count"`
-	LocaliseKeyName string		`json:"localise_key"`
-	SubTypes        []string	`json:"sub_types"`
+	Group           string   `json:"group"`
+	Count           int      `json:"count"`
+	LocaliseKeyName string   `json:"localise_key"`
+	Types           []string `json:"types"`
 }
 
 // ContentItem represents each search result

--- a/model/search.go
+++ b/model/search.go
@@ -58,11 +58,16 @@ type ContentType struct {
 
 // ContentItem represents each search result
 type ContentItem struct {
-	Description Description `json:"description"`
+	Type        ContentItemType `json:"type"`
+	Description Description     `json:"description"`
+	URI         string          `json:"uri"`
+	Matches     *Matches        `json:"matches,omitempty"`
+}
 
-	Type    string   `json:"type"`
-	URI     string   `json:"uri"`
-	Matches *Matches `json:"matches,omitempty"`
+// ContentItemType represents the type of each search result
+type ContentItemType struct {
+	Type            string `json:"type"`
+	LocaliseKeyName string `json:"localise_key"`
 }
 
 // Description represents each search result description


### PR DESCRIPTION
### What
**Describe what you have changed and why.**
1. Change the field names in `ContentType` struct from `Type` -> `Group` and `SubTypes` -> `Types`. This gives clarity on what each field means. This is an example of how each field links to each other:

```
Publication (Category)
-> Article (Group)
-> -> "articles","static_articles" (Types)
```

2. Moved the logic to get the search result `Type` `LocaliseKey` from the template to the controller 

### How to review
**Describe the steps required to test the changes.**
- Check if the code changes makes sense
- Run locally and see if the search page is functioning as normal
- Check if the tests pass

### Who can review
**Describe who worked on the changes, so that other people can review.**
Anyone