### PR TITLE
Fteaure/search pagination typo

### DIFF
--- a/assets/templates/search.tmpl
+++ b/assets/templates/search.tmpl
@@ -25,7 +25,7 @@
         {{ template "partials/department" . }}
         {{ template "partials/results" . }}
       </div>
-      <div class="search__pagintion">
+      <div class="search__pagination">
         {{ template "partials/pagination" . }}
       </div>
     </section>

--- a/config/config.go
+++ b/config/config.go
@@ -37,7 +37,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9002/dist/assets"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/9fc59f8"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/08558e0"
 	}
 	return cfg, nil
 }


### PR DESCRIPTION
### What

- Updated `seach__pagination` type 
- updated commit ref to dp-design-system

### How to review

when doing a filter on `data -> datasets` only a single pagination item should appear

![image](https://user-images.githubusercontent.com/5684161/150154944-4f4f8528-7f80-467e-99fb-2b9f0b889c5c.png)



### Who can review

Anyone
