### PR TITLE
Remove topic filter type from web filters

### DIFF
--- a/data/filter.go
+++ b/data/filter.go
@@ -28,6 +28,7 @@ type ContentType struct {
 	Count           int      `json:"count"`
 	Group           string   `json:"group"`
 	Types           []string `json:"types"`
+	ShowInWebUI     bool     `json:"show_in_web_ui"`
 }
 
 var defaultContentTypes = "article," +
@@ -74,6 +75,7 @@ var (
 		LocaliseKeyName: "StatisticalBulletin",
 		Group:           "bulletin",
 		Types:           []string{"bulletin"},
+		ShowInWebUI:     true,
 	}
 
 	// Article - Search information specific for articles
@@ -81,6 +83,7 @@ var (
 		LocaliseKeyName: "Article",
 		Group:           "article",
 		Types:           []string{"article", "article_download"},
+		ShowInWebUI:     true,
 	}
 
 	// Compendium - Search information specific for compendium
@@ -88,6 +91,7 @@ var (
 		LocaliseKeyName: "Compendium",
 		Group:           "compendia",
 		Types:           []string{"compendium_landing_page"},
+		ShowInWebUI:     true,
 	}
 
 	// TimeSeries - Search information specific for time series
@@ -95,6 +99,7 @@ var (
 		LocaliseKeyName: "TimeSeries",
 		Group:           "time_series",
 		Types:           []string{"timeseries"},
+		ShowInWebUI:     true,
 	}
 
 	// Datasets - Search information specific for datasets
@@ -102,6 +107,7 @@ var (
 		LocaliseKeyName: "Datasets",
 		Group:           "datasets",
 		Types:           []string{"dataset_landing_page", "timeseries_dataset"},
+		ShowInWebUI:     true,
 	}
 
 	// UserRequestedData - Search information specific for user requested data
@@ -109,6 +115,7 @@ var (
 		LocaliseKeyName: "UserRequestedData",
 		Group:           "user_requested_data",
 		Types:           []string{"static_adhoc"},
+		ShowInWebUI:     true,
 	}
 
 	// Methodology - Search information specific for methodologies
@@ -116,6 +123,7 @@ var (
 		LocaliseKeyName: "Methodology",
 		Group:           "methodology",
 		Types:           []string{"static_methodology", "static_methodology_download", "static_qmi"},
+		ShowInWebUI:     true,
 	}
 
 	// CorporateInformation - Search information specific for corporate information
@@ -123,6 +131,7 @@ var (
 		LocaliseKeyName: "CorporateInformation",
 		Group:           "corporate_information",
 		Types:           []string{"static_foi", "static_page", "static_landing_page", "static_article"},
+		ShowInWebUI:     true,
 	}
 
 	// ProductPage - Search information specific for product pages
@@ -130,6 +139,7 @@ var (
 		LocaliseKeyName: "ProductPage",
 		Group:           "product_page",
 		Types:           []string{"product_page"},
+		ShowInWebUI:     false,
 	}
 
 	// filterOptions contains all the possible filter available on the search page

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -295,6 +295,10 @@ func mapFilters(page *model.SearchPage, categories []data.Category, queryParams 
 		var subTypes []model.Filter
 		if len(category.ContentTypes) > 0 {
 			for _, contentType := range category.ContentTypes {
+				if !contentType.ShowInWebUI {
+					filter.NumberOfResults -= 1
+					continue
+				}
 				var subType model.Filter
 				subType.LocaliseKeyName = contentType.LocaliseKeyName
 				subType.NumberOfResults = contentType.Count

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ONSdigital/dp-frontend-search-controller/config"
 	"github.com/ONSdigital/dp-frontend-search-controller/data"
 	"github.com/ONSdigital/dp-renderer/model"
-	"github.com/davecgh/go-spew/spew"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -144,8 +143,6 @@ func TestUnitCreateSearchPageSuccess(t *testing.T) {
 				So(testMatchesDescDatasetID[0].Start, ShouldEqual, 26)
 				So(testMatchesDescDatasetID[0].End, ShouldEqual, 30)
 
-				spew.Dump(sp.Data.Filters)
-				//So(sp.Data.Filters, ShouldEqual, 1)
 				So(len(sp.Data.Filters[0].FilterKey), ShouldEqual, 3)
 				So(sp.Data.Filters[0].LocaliseKeyName, ShouldEqual, "Publication")
 				So(sp.Data.Filters[0].IsChecked, ShouldBeTrue)
@@ -162,6 +159,7 @@ func TestUnitCreateSearchPageSuccess(t *testing.T) {
 				So(sp.Data.Filters[0].Types[2].LocaliseKeyName, ShouldEqual, "Compendium")
 				So(sp.Data.Filters[0].Types[2].IsChecked, ShouldBeFalse)
 				So(sp.Data.Filters[0].Types[2].NumberOfResults, ShouldEqual, 0)
+				So(len(sp.Data.Filters[2].Types), ShouldEqual, 2)
 
 				So(sp.Department.Code, ShouldEqual, "dept-code")
 				So(sp.Department.URL, ShouldEqual, "www.dept.com")


### PR DESCRIPTION
### What

Remove topic filter type from web filters

### How to review

- Run search
- "Topic" filter type under "Other" should no longer appear
- "Other" result count should be correct

### Who can review

Anyone
