### PR TITLE
fix filter item counts appearing as -1

### DIFF
--- a/assets/templates/partials/filter.tmpl
+++ b/assets/templates/partials/filter.tmpl
@@ -24,7 +24,7 @@
             <a href="/search{{ if .Data.Query }}?q={{ .Data.Query}}{{end}}" id="clear-search" class="float-right font-size--18">{{ localise "ClearAll" $lang 1 }}</a>
             <p class="ons-checkboxes__label">Show only:</p>
             {{ range $index, $topFilter := $filters}}
-                {{if ne $topFilter.NumberOfResults 0}}
+                {{if gt $topFilter.NumberOfResults 0}}
                     <div class="ons-checkboxes__items">
                         <span class="ons-checkboxes__item ons-checkboxes__item--no-border">
                             <span class="ons-checkbox ons-checkbox--no-border category-filter">

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -297,7 +297,7 @@ func mapFilters(page *model.SearchPage, categories []data.Category, queryParams 
 		var subTypes []model.Filter
 		if len(category.ContentTypes) > 0 {
 			for _, contentType := range category.ContentTypes {
-				if !contentType.ShowInWebUI {
+				if !contentType.ShowInWebUI && contentType.Count > 0 {
 					filter.NumberOfResults -= 1
 					continue
 				}

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -159,7 +159,7 @@ func TestUnitCreateSearchPageSuccess(t *testing.T) {
 				So(sp.Data.Filters[0].Types[2].LocaliseKeyName, ShouldEqual, "Compendium")
 				So(sp.Data.Filters[0].Types[2].IsChecked, ShouldBeFalse)
 				So(sp.Data.Filters[0].Types[2].NumberOfResults, ShouldEqual, 0)
-				So(len(sp.Data.Filters[2].Types), ShouldEqual, 2)
+				So(len(sp.Data.Filters[2].Types), ShouldEqual, 3)
 
 				So(sp.Department.Code, ShouldEqual, "dept-code")
 				So(sp.Department.URL, ShouldEqual, "www.dept.com")


### PR DESCRIPTION
### What

fix filter item counts appearing as -1
- check count is above 0 before removing 1 from count otherwise skip
- show filter item if greater than one rather than equal to 0, seems a bit more robust and fixes this issue if any other mapper issues

### How to review

Search for `CF36` and there will be a -1 count for "Other" after pulling these changes "Other" should have zero count and not appear. 
If you don't have content for `CF36` locally you can point your search controller at the prod api e.g. `make debug API_ROUTER_URL="https://api.beta.ons.gov.uk/v1"`

### Who can review

Anyone
