### PR TITLE
a loading message on the search page

### DIFF
--- a/assets/templates/partials/results.tmpl
+++ b/assets/templates/partials/results.tmpl
@@ -4,6 +4,14 @@
 {{ $totalSearchPosition := multiply (subtract $currentPage 1) $itemsPerPage }}
 {{ $response := .Data.Response }}
 <div id="results">
+    <div id="results-loading" class="ons-panel ons-panel--info ons-panel--no-title hide">
+        <span class="ons-u-vh">Important information: </span>
+        <div class="ons-panel__body">
+        <p data-error-message="The results failed to load, please refresh.">
+            Loading search results.
+        </p>
+        </div>
+    </div>
     <ul class="flush--padding">
     {{ range $i, $item := .Data.Response.Items }}
         {{ $currentPosition := add $i 1 }}

--- a/config/config.go
+++ b/config/config.go
@@ -39,7 +39,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9002/dist/assets"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/66cc1c1"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/e9d9b0b"
 	}
 	return cfg, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -39,7 +39,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9002/dist/assets"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/17dfae1"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/66cc1c1"
 	}
 	return cfg, nil
 }


### PR DESCRIPTION
### What

A loading indicator to show results are taking a while to arrive, there is a data label included as an alternative message in the case of server issues.

> As a website user, with a slow internet connection
> I want to know that my search worked
> so that I am reassured and do not refresh
> 
> 

Required dp-design-system changes: https://github.com/ONSdigital/dp-design-system/pull/85

https://trello.com/c/08BLV9Xr/1058-add-loading-indicator-to-search-results-page?filter=label:Front%20End

### How to review

Read or pull. Don't forget the dp-design-system counterpart listed above.

### Who can review

Anyone.
