### PR TITLE
update reference to library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ONSdigital/dp-cookies v0.3.3
 	github.com/ONSdigital/dp-healthcheck v1.1.0
 	github.com/ONSdigital/dp-net v1.2.0
-	github.com/ONSdigital/dp-renderer v1.12.0
+	github.com/ONSdigital/dp-renderer v1.31.0
 	github.com/ONSdigital/log.go/v2 v2.0.9
 	github.com/cucumber/godog v0.11.0
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,8 @@ github.com/ONSdigital/dp-renderer v1.11.9 h1:3UdVO0kmXlfRrjyLw/Ggeqs9fuluyVTvzET
 github.com/ONSdigital/dp-renderer v1.11.9/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
 github.com/ONSdigital/dp-renderer v1.12.0 h1:PtcE8KcZP1vjSmdcleFT2p+KtjnVKv4QSy7wFnFpG2Q=
 github.com/ONSdigital/dp-renderer v1.12.0/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
+github.com/ONSdigital/dp-renderer v1.31.0 h1:/ZHcibRthXcINKrsALmd6Cs7cXxoNa9sGQKlr1Jmm4k=
+github.com/ONSdigital/dp-renderer v1.31.0/go.mod h1:odKmVudLXN9WaenfrKgGGrfmZARZFemSNtSy6gxTue8=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
 github.com/ONSdigital/log.go v1.0.0/go.mod h1:UnGu9Q14gNC+kz0DOkdnLYGoqugCvnokHBRBxFRpVoQ=
 github.com/ONSdigital/log.go v1.0.1-0.20200805084515-ee61165ea36a/go.mod h1:dDnQATFXCBOknvj6ZQuKfmDhbOWf3e8mtV+dPEfWJqs=


### PR DESCRIPTION
### What

Update reference to most recent dp-renderer release 1.31.0. 

### How to review

See that reference to dp-renderer matches [latest release](https://github.com/ONSdigital/dp-renderer/releases/tag/v1.31.0) 

### Who can review

Anyone. 
