### PR TITLE
update reference

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/ONSdigital/dp-healthcheck v1.3.0
 	github.com/ONSdigital/dp-net v1.4.1
 	github.com/ONSdigital/dp-net/v2 v2.4.0
-	github.com/ONSdigital/dp-renderer v1.21.1
+	github.com/ONSdigital/dp-renderer v1.31.0
 	github.com/ONSdigital/log.go/v2 v2.2.0
 	github.com/cucumber/godog v0.11.0
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,8 @@ github.com/ONSdigital/dp-net/v2 v2.4.0 h1:GYJM8ZFGfWOAjUUMO8rXavowAT700q3Zi/vYjc
 github.com/ONSdigital/dp-net/v2 v2.4.0/go.mod h1:8X7E1wiJxL59qaDFt3ShDfFLfIGs4WMRPx1sZIgAqbU=
 github.com/ONSdigital/dp-renderer v1.21.1 h1:dSvaby6bIuLGlL4MTBFzQaJFtZgt21X0wbb9DY1I7E8=
 github.com/ONSdigital/dp-renderer v1.21.1/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
+github.com/ONSdigital/dp-renderer v1.31.0 h1:/ZHcibRthXcINKrsALmd6Cs7cXxoNa9sGQKlr1Jmm4k=
+github.com/ONSdigital/dp-renderer v1.31.0/go.mod h1:odKmVudLXN9WaenfrKgGGrfmZARZFemSNtSy6gxTue8=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
 github.com/ONSdigital/log.go v1.0.0/go.mod h1:UnGu9Q14gNC+kz0DOkdnLYGoqugCvnokHBRBxFRpVoQ=
 github.com/ONSdigital/log.go v1.0.1-0.20200805084515-ee61165ea36a/go.mod h1:dDnQATFXCBOknvj6ZQuKfmDhbOWf3e8mtV+dPEfWJqs=


### PR DESCRIPTION
### What

Update library reference to 1.31.0

### How to review

See that reference to dp-renderer library in go.mod file matches the [latest release](https://github.com/ONSdigital/dp-renderer/releases/tag/v1.31.0) for the renderer. 

### Who can review

Anyone.
