### PR TITLE
add service auth token

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,25 +20,28 @@ No further dependencies other than those defined in `go.mod`
 
 ## Configuration
 
-| Environment variable              | Default                      | Description
-| --------------------------------- | ---------------------------- | --------------------------------------------------
-| API_ROUTER_URL                    | http://localhost:23200/v1    | The URL of the [dp-api-router](https://github.com/ONSdigital/dp-api-router)
-| BIND_ADDR                         | localhost:25000              | The host and port to bind to
-| DEBUG                             | false                        | Enable debug mode
-| DEFAULT_LIMIT                     | 10                           | The default limit of search results in a page
-| DEFAULT_MAXIMUM_LIMIT             | 50                           | The default maximum limit of search results in a page
-| DEFAULT_MAXIMUM_SEARCH_RESULTS    | 500                          | The default maximum search results
-| DEFAULT_OFFSET                    | 0                            | The default offset of search results
-| DEFAULT_PAGE                      | 1                            | The default current page of search results
-| DEFAULT_SORT                      | relevance                    | The default sort of search results
-| ENABLE_CENSUS_TOPIC_FILTER_OPTION | false                        | Enable filtering on various census topics
-| GRACEFUL_SHUTDOWN_TIMEOUT         | 5s                           | The graceful shutdown timeout in seconds (`time.Duration` format)
-| HEALTHCHECK_CRITICAL_TIMEOUT      | 90s                          | Time to wait until an unhealthy dependent propagates its state to make this app unhealthy (`time.Duration` format)
-| HEALTHCHECK_INTERVAL              | 30s                          | Time between self-healthchecks (`time.Duration` format)
-| NO_INDEX_ENABLED                  | false                        | If true then prevents most search engine web crawlers from indexing the search pages
-| PATTERN_LIBRARY_ASSETS_PATH       | ""                           | Pattern library location
-| SITE_DOMAIN                       | localhost                    |
-| SUPPORTED_LANGUAGES               | [2]string{"en", "cy"}        | Supported languages
+| Environment variable                   | Default                      | Description
+| ---------------------------------      | ---------------------------- | --------------------------------------------------
+| API_ROUTER_URL                         | http://localhost:23200/v1    | The URL of the [dp-api-router](https://github.com/ONSdigital/dp-api-router)
+| BIND_ADDR                              | localhost:25000              | The host and port to bind to
+| CACHE_CENSUS_TOPICS_UPDATE_INTERVAL    | 30m                          | The time interval to update cache for census topics (`time.Duration` format)
+| DEBUG                                  | false                        | Enable debug mode
+| DEFAULT_LIMIT                          | 10                           | The default limit of search results in a page
+| DEFAULT_MAXIMUM_LIMIT                  | 50                           | The default maximum limit of search results in a page
+| DEFAULT_MAXIMUM_SEARCH_RESULTS         | 500                          | The default maximum search results
+| DEFAULT_OFFSET                         | 0                            | The default offset of search results
+| DEFAULT_PAGE                           | 1                            | The default current page of search results
+| DEFAULT_SORT                           | relevance                    | The default sort of search results
+| ENABLE_CENSUS_TOPIC_FILTER_OPTION      | false                        | Enable filtering on various census topics
+| GRACEFUL_SHUTDOWN_TIMEOUT              | 5s                           | The graceful shutdown timeout in seconds (`time.Duration` format)
+| HEALTHCHECK_CRITICAL_TIMEOUT           | 90s                          | Time to wait until an unhealthy dependent propagates its state to make this app unhealthy (`time.Duration` format)
+| HEALTHCHECK_INTERVAL                   | 30s                          | Time between self-healthchecks (`time.Duration` format)
+| IS_PUBLISHING                          | false                        | Mode in which service is running
+| NO_INDEX_ENABLED                       | false                        | If true then prevents most search engine web crawlers from indexing the search pages
+| PATTERN_LIBRARY_ASSETS_PATH            | ""                           | Pattern library location
+| SERVICE_AUTH_TOKEN                     | ""                           | This is required to identify the controller when it calls the topic API via the API router in publishing mode
+| SITE_DOMAIN                            | localhost                    |
+| SUPPORTED_LANGUAGES                    | [2]string{"en", "cy"}        | Supported languages
 
 ## Contributing
 

--- a/cache/census_topic_pub_test.go
+++ b/cache/census_topic_pub_test.go
@@ -84,7 +84,7 @@ func mockGetSubtopicsIDsPrivate(ctx context.Context, subtopicsIDChan chan string
 
 	go func() {
 		defer wg.Done()
-		getSubtopicsIDsPrivate(ctx, subtopicsIDChan, topicClient, topLevelTopicID)
+		getSubtopicsIDsPrivate(ctx, "", subtopicsIDChan, topicClient, topLevelTopicID)
 		close(subtopicsIDChan)
 	}()
 
@@ -124,7 +124,7 @@ func TestUpdateCensusTopicPrivate(t *testing.T) {
 
 	Convey("Given census root topic does exist and has subtopics", t, func() {
 		Convey("When UpdateCensusTopicPrivate is called", func() {
-			respCensusTopicCache, err := UpdateCensusTopicPrivate(ctx, mockedTopicClient)()
+			respCensusTopicCache, err := UpdateCensusTopicPrivate(ctx, "", mockedTopicClient)()
 
 			Convey("Then the census topic cache is returned", func() {
 				So(respCensusTopicCache, ShouldHaveSameTypeAs, expectedCensusTopicCache)
@@ -145,7 +145,7 @@ func TestUpdateCensusTopicPrivate(t *testing.T) {
 		}
 
 		Convey("When UpdateCensusTopicPrivate is called", func() {
-			respCensusTopicCache, err := UpdateCensusTopicPrivate(ctx, failedRootTopicClient)()
+			respCensusTopicCache, err := UpdateCensusTopicPrivate(ctx, "", failedRootTopicClient)()
 
 			Convey("Then an error should be returned", func() {
 				So(err, ShouldNotBeNil)
@@ -167,7 +167,7 @@ func TestUpdateCensusTopicPrivate(t *testing.T) {
 		}
 
 		Convey("When UpdateCensusTopicPrivate is called", func() {
-			respCensusTopicCache, err := UpdateCensusTopicPrivate(ctx, rootTopicsNilClient)()
+			respCensusTopicCache, err := UpdateCensusTopicPrivate(ctx, "", rootTopicsNilClient)()
 
 			Convey("Then an error should be returned", func() {
 				So(err, ShouldNotBeNil)
@@ -196,7 +196,7 @@ func TestUpdateCensusTopicPrivate(t *testing.T) {
 		}
 
 		Convey("When UpdateCensusTopicPrivate is called", func() {
-			respCensusTopicCache, err := UpdateCensusTopicPrivate(ctx, censusTopicNotExistClient)()
+			respCensusTopicCache, err := UpdateCensusTopicPrivate(ctx, "", censusTopicNotExistClient)()
 
 			Convey("Then an error should be returned", func() {
 				So(err, ShouldNotBeNil)
@@ -233,7 +233,7 @@ func TestGetRootTopicCachePrivate(t *testing.T) {
 	Convey("Given topic has subtopics", t, func() {
 
 		Convey("When getRootTopicCachePrivate is called", func() {
-			respCensusTopicCache := getRootTopicCachePrivate(ctx, subtopicsIDChan, mockedTopicClient, testCensusRootTopic)
+			respCensusTopicCache := getRootTopicCachePrivate(ctx, "", subtopicsIDChan, mockedTopicClient, testCensusRootTopic)
 
 			Convey("Then the census topic cache is returned", func() {
 				So(respCensusTopicCache, ShouldResemble, expectedCensusTopicCache)

--- a/config/config.go
+++ b/config/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	IsPublishing                   bool          `envconfig:"IS_PUBLISHING"`
 	NoIndexEnabled                 bool          `envconfig:"NO_INDEX_ENABLED"`
 	PatternLibraryAssetsPath       string        `envconfig:"PATTERN_LIBRARY_ASSETS_PATH"`
+	ServiceAuthToken               string        `envconfig:"SERVICE_AUTH_TOKEN"   json:"-"`
 	SiteDomain                     string        `envconfig:"SITE_DOMAIN"`
 	SupportedLanguages             []string      `envconfig:"SUPPORTED_LANGUAGES"`
 }
@@ -69,6 +70,7 @@ func get() (*Config, error) {
 		HealthCheckInterval:            30 * time.Second,
 		IsPublishing:                   false,
 		NoIndexEnabled:                 false,
+		ServiceAuthToken:               "",
 		SiteDomain:                     "localhost",
 		SupportedLanguages:             []string{"en", "cy"},
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -37,6 +37,7 @@ func TestConfig(t *testing.T) {
 				So(cfg.HealthCheckInterval, ShouldEqual, 30*time.Second)
 				So(cfg.IsPublishing, ShouldBeFalse)
 				So(cfg.NoIndexEnabled, ShouldBeFalse)
+				So(cfg.ServiceAuthToken, ShouldNotBeEmpty)
 				So(cfg.SiteDomain, ShouldEqual, "localhost")
 				So(cfg.SupportedLanguages, ShouldResemble, []string{"en", "cy"})
 			})

--- a/service/service.go
+++ b/service/service.go
@@ -83,7 +83,7 @@ func (svc *Service) Init(ctx context.Context, cfg *config.Config, serviceList *E
 		return err
 	}
 	if cfg.IsPublishing {
-		svc.Cache.CensusTopic.AddUpdateFunc(cache.CensusTopicTitle, cache.UpdateCensusTopicPrivate(ctx, clients.Topic))
+		svc.Cache.CensusTopic.AddUpdateFunc(cache.CensusTopicTitle, cache.UpdateCensusTopicPrivate(ctx, cfg.ServiceAuthToken, clients.Topic))
 	} else {
 		svc.Cache.CensusTopic.AddUpdateFunc(cache.CensusTopicTitle, cache.UpdateCensusTopicPublic(ctx, clients.Topic))
 	}


### PR DESCRIPTION
### What
**Describe what you have changed and why.**
- Add SERVICE_AUTH_TOKEN which is required to identify the controller when it calls the topic API via the API router in publishing mode
- This fixes issues for caching census topics in the controller when in publishing mode

### How to review
**Describe the steps required to test the changes.**
- Check if the code changes make sense

### Who can review
**Describe who worked on the changes, so that other people can review.**
- Anyone