### PR TITLE
allow controller to use es710 data response as well

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,14 +11,14 @@ require (
 	github.com/ONSdigital/dp-healthcheck v1.3.0
 	github.com/ONSdigital/dp-net v1.4.1
 	github.com/ONSdigital/dp-net/v2 v2.4.0
-	github.com/ONSdigital/dp-renderer v1.35.0
+	github.com/ONSdigital/dp-renderer v1.36.0
 	github.com/ONSdigital/log.go/v2 v2.2.0
 	github.com/cucumber/godog v0.12.5
 	github.com/gorilla/mux v1.8.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/maxcnunes/httpfake v1.2.4
 	github.com/smartystreets/goconvey v1.7.2
-	github.com/stretchr/testify v1.7.5
+	github.com/stretchr/testify v1.8.0
 )
 
 require github.com/kevinburke/go-bindata v3.23.0+incompatible // indirect
@@ -28,7 +28,7 @@ require (
 	github.com/ONSdigital/dp-api-clients-go v1.43.0 // indirect
 	github.com/ONSdigital/dp-mongodb-in-memory v1.3.1 // indirect
 	github.com/ONSdigital/dp-topic-api v0.9.0
-	github.com/aws/aws-sdk-go v1.44.43 // indirect
+	github.com/aws/aws-sdk-go v1.44.44 // indirect
 	github.com/c2h5oh/datasize v0.0.0-20220606134207-859f65c6625b // indirect
 	github.com/chromedp/cdproto v0.0.0-20220624030920-1958475a8671 // indirect
 	github.com/chromedp/chromedp v0.8.2 // indirect
@@ -56,7 +56,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/jtolds/gls v4.20.0+incompatible // indirect
 	github.com/justinas/alice v1.2.0 // indirect
-	github.com/klauspost/compress v1.15.6 // indirect
+	github.com/klauspost/compress v1.15.7 // indirect
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -70,8 +70,8 @@ github.com/ONSdigital/dp-net v1.4.1 h1:hfhtQ2l7pGtC2nBze7YtFzvkVEMCYprHgojNYVPL1
 github.com/ONSdigital/dp-net v1.4.1/go.mod h1:VK8dah+G0TeVO/Os/w17Rk4WM6hIGmdUXrm8fBWyC+g=
 github.com/ONSdigital/dp-net/v2 v2.4.0 h1:GYJM8ZFGfWOAjUUMO8rXavowAT700q3Zi/vYjc2jh8o=
 github.com/ONSdigital/dp-net/v2 v2.4.0/go.mod h1:8X7E1wiJxL59qaDFt3ShDfFLfIGs4WMRPx1sZIgAqbU=
-github.com/ONSdigital/dp-renderer v1.35.0 h1:6wBQe2iNp5qQNa+JfmAsLl/d3zWeNffwOyldoqTLRTE=
-github.com/ONSdigital/dp-renderer v1.35.0/go.mod h1:odKmVudLXN9WaenfrKgGGrfmZARZFemSNtSy6gxTue8=
+github.com/ONSdigital/dp-renderer v1.36.0 h1:iiOP8qZEr+4xlNZ9vXz1WE+/YVHHaemPAVpFC1YAuAY=
+github.com/ONSdigital/dp-renderer v1.36.0/go.mod h1:odKmVudLXN9WaenfrKgGGrfmZARZFemSNtSy6gxTue8=
 github.com/ONSdigital/dp-topic-api v0.9.0 h1:a33BC7DPEaCk8PrwUQDRA5S+oAkFwo1TVMNnXSb6iV4=
 github.com/ONSdigital/dp-topic-api v0.9.0/go.mod h1:MipguYB6NVmJtzcdvmQ2DDpVY31PPPOiSFiWDzV5bWw=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
@@ -87,8 +87,8 @@ github.com/ONSdigital/log.go/v2 v2.0.9/go.mod h1:VyTDkL82FtiAkaNFaT+bURBhLbP7NsI
 github.com/ONSdigital/log.go/v2 v2.2.0 h1:Rkv6Gbfa3Jzy5AfPWkUDEnpFNhzYyaGQ6f7YUdBKnHs=
 github.com/ONSdigital/log.go/v2 v2.2.0/go.mod h1:i0eFlPDlF1fI4k0/SvXhQIkyQxs676EySpYPj3rQy+I=
 github.com/aws/aws-sdk-go v1.38.15/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
-github.com/aws/aws-sdk-go v1.44.43 h1:gILXnQAOkfAV9dhdXOUlnVTGM3AiOQFqwQmJJ9R7rUE=
-github.com/aws/aws-sdk-go v1.44.43/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
+github.com/aws/aws-sdk-go v1.44.44 h1:XLEcUxILvVBYO/frO+TTCd8NIxklX/ZOzSJSBZ+b7B8=
+github.com/aws/aws-sdk-go v1.44.44/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/c2h5oh/datasize v0.0.0-20200825124411-48ed595a09d2/go.mod h1:S/7n9copUssQ56c7aAgHqftWO4LTf4xY6CGWt8Bc+3M=
 github.com/c2h5oh/datasize v0.0.0-20220606134207-859f65c6625b h1:6+ZFm0flnudZzdSE0JxlhR2hKnGPcNB35BjQf4RYQDY=
 github.com/c2h5oh/datasize v0.0.0-20220606134207-859f65c6625b/go.mod h1:S/7n9copUssQ56c7aAgHqftWO4LTf4xY6CGWt8Bc+3M=
@@ -257,8 +257,8 @@ github.com/kevinburke/go-bindata v3.23.0+incompatible h1:rqNOXZlqrYhMVVAsQx8wuc+
 github.com/kevinburke/go-bindata v3.23.0+incompatible/go.mod h1:/pEEZ72flUW2p0yi30bslSp9YqD9pysLxunQDdb2CPM=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
-github.com/klauspost/compress v1.15.6 h1:6D9PcO8QWu0JyaQ2zUMmu16T1T+zjjEpP91guRsvDfY=
-github.com/klauspost/compress v1.15.6/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
+github.com/klauspost/compress v1.15.7 h1:7cgTQxJCU/vy+oP/E3B9RGbQTgbiVzIJWIKOLoAsPok=
+github.com/klauspost/compress v1.15.7/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
@@ -321,8 +321,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.5 h1:s5PTfem8p8EbKQOctVV53k6jCJt3UX4IEJzwh+C324Q=
-github.com/stretchr/testify v1.7.5/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/unrolled/render v1.4.0/go.mod h1:cK4RSTTVdND5j9EYEc0LAMOvdG11JeiKjyjfyZRvV2w=

--- a/mapper/data/mock_legacy_search_response.json
+++ b/mapper/data/mock_legacy_search_response.json
@@ -1,0 +1,96 @@
+{
+    "count": 1,
+    "took": 96,
+    "content_types": [
+        {
+            "type": "article",
+            "count": 1
+        }
+    ],
+    "items": [
+        {
+            "description": {
+                "contact": {
+                    "email": "test@ons.gov.uk",
+                    "name": "Name",
+                    "telephone": "123"
+                },
+                "edition": "1995 to 2013",
+                "keywords": [
+                    "regional house prices",
+                    "property prices",
+                    "area with cheapest houses",
+                    "area with most expensive houses"
+                ],
+                "latest_release": true,
+                "meta_description": "Test Meta Description",
+                "national_statistic": false,
+                "release_date": "2015-02-17T00:00:00.000Z",
+                "source": "",
+                "summary": "Test Summary",
+                "title": "Title Title",
+                "unit": "",
+                "highlight": {
+                    "summary": "Test Summary",
+                    "title": "Title Title",
+                    "keywords": [
+                        "regional house prices",
+                        "property prices",
+                        "area with cheapest houses",
+                        "area with most expensive houses"
+                    ],
+                    "edition": "1995 to 2013"
+                }
+            },
+            "matches": {
+                "description": {
+                    "summary": [
+                        {
+                            "value": "summary",
+                            "start": 1,
+                            "end": 5
+                        }
+
+                    ],
+                    "title": [
+                        {
+                            "value": "title",
+                            "start": 6,
+                            "end": 10
+                        }
+                    ],
+                    "edition": [
+                        {
+                            "value": "edition",
+                            "start": 11,
+                            "end": 15
+                        }
+                    ],
+                    "meta_description": [
+                        {
+                            "value": "meta_description",
+                            "start": 16,
+                            "end": 20
+                        }
+                    ],
+                    "keywords": [
+                        {
+                            "value": "keywords",
+                            "start": 21,
+                            "end": 25
+                        }
+                    ],
+                    "dataset_id": [
+                        {
+                            "value": "dataset_id",
+                            "start": 26,
+                            "end": 30
+                        }
+                    ]
+                }
+            },
+            "type": "article",
+            "uri": "/uri1/housing/articles/uri2/2015-02-17"
+        }
+    ]
+}

--- a/mapper/data/mock_search_response.json
+++ b/mapper/data/mock_search_response.json
@@ -1,4 +1,5 @@
 {
+    "es_710": true,
     "count": 1,
     "took": 96,
     "content_types": [
@@ -9,85 +10,25 @@
     ],
     "items": [
         {
-            "description": {
-                "contact": {
-                    "email": "test@ons.gov.uk",
-                    "name": "Name",
-                    "telephone": "123"
-                },
-                "edition": "1995 to 2013",
+            "keywords": [
+                "regional house prices",
+                "property prices",
+                "area with cheapest houses",
+                "area with most expensive houses"
+            ],
+            "meta_description": "Test Meta Description",
+            "release_date": "2015-02-17T00:00:00.000Z",
+            "summary": "Test Summary",
+            "title": "Title Title",
+            "highlight": {
+                "summary": "Test Summary",
+                "title": "Title Title",
                 "keywords": [
                     "regional house prices",
                     "property prices",
                     "area with cheapest houses",
                     "area with most expensive houses"
-                ],
-                "latest_release": true,
-                "meta_description": "Test Meta Description",
-                "national_statistic": false,
-                "release_date": "2015-02-17T00:00:00.000Z",
-                "source": "",
-                "summary": "Test Summary",
-                "title": "Title Title",
-                "unit": "",
-                "highlight": {
-                    "summary": "Test Summary",
-                    "title": "Title Title",
-                    "keywords": [
-                        "regional house prices",
-                        "property prices",
-                        "area with cheapest houses",
-                        "area with most expensive houses"
-                    ],
-                    "edition": "1995 to 2013"
-                }
-            },
-            "matches": {
-                "description": {
-                    "summary": [
-                        {
-                            "value": "summary",
-                            "start": 1,
-                            "end": 5
-                        }
-
-                    ],
-                    "title": [
-                        {
-                            "value": "title",
-                            "start": 6,
-                            "end": 10
-                        }
-                    ],
-                    "edition": [
-                        {
-                            "value": "edition",
-                            "start": 11,
-                            "end": 15
-                        }
-                    ],
-                    "meta_description": [
-                        {
-                            "value": "meta_description",
-                            "start": 16,
-                            "end": 20
-                        }
-                    ],
-                    "keywords": [
-                        {
-                            "value": "keywords",
-                            "start": 21,
-                            "end": 25
-                        }
-                    ],
-                    "dataset_id": [
-                        {
-                            "value": "dataset_id",
-                            "start": 26,
-                            "end": 30
-                        }
-                    ]
-                }
+                ]
             },
             "type": "article",
             "uri": "/uri1/housing/articles/uri2/2015-02-17"

--- a/mapper/mapper_es710.go
+++ b/mapper/mapper_es710.go
@@ -1,0 +1,76 @@
+package mapper
+
+import (
+	searchC "github.com/ONSdigital/dp-api-clients-go/v2/site-search"
+	"github.com/ONSdigital/dp-frontend-search-controller/data"
+	model "github.com/ONSdigital/dp-frontend-search-controller/model"
+)
+
+func mapResponse(page *model.SearchPage, respC searchC.Response, categories []data.Category) {
+	page.Data.Response.Count = respC.Count
+
+	mapResponseCategories(page, categories)
+
+	mapResponseItems(page, respC)
+
+	page.Data.Response.Suggestions = respC.Suggestions
+	page.Data.Response.AdditionalSuggestions = respC.AdditionalSuggestions
+}
+
+func mapResponseItems(page *model.SearchPage, respC searchC.Response) {
+	itemPage := []model.ContentItem{}
+
+	for _, itemC := range respC.Items {
+		item := model.ContentItem{}
+
+		mapItemDescription(&item, itemC)
+
+		mapItemHighlight(&item, itemC)
+
+		item.Type.Type = itemC.Type
+		item.Type.LocaliseKeyName = data.GetGroupLocaliseKey(itemC.Type)
+
+		item.URI = itemC.URI
+
+		mapItemMatches(&item, itemC)
+
+		itemPage = append(itemPage, item)
+	}
+
+	page.Data.Response.Items = itemPage
+}
+
+func mapItemDescription(item *model.ContentItem, itemC searchC.ContentItem) {
+
+	item.Description = model.Description{
+		DatasetID:       itemC.DatasetID,
+		Language:        itemC.Language,
+		MetaDescription: itemC.MetaDescription,
+		ReleaseDate:     itemC.ReleaseDate,
+		Summary:         itemC.Summary,
+		Title:           itemC.Title,
+	}
+
+	if len(itemC.Keywords) != 0 {
+		item.Description.Keywords = &itemC.Keywords
+	} else {
+		item.Description.Keywords = nil
+	}
+}
+
+func mapItemHighlight(item *model.ContentItem, itemC searchC.ContentItem) {
+	highlightC := itemC.Highlight
+
+	if highlightC != nil {
+		item.Description.Highlight = model.Highlight{
+			DatasetID:       highlightC.DatasetID,
+			Edition:         highlightC.Edition,
+			Keywords:        highlightC.Keywords,
+			MetaDescription: highlightC.MetaDescription,
+			Summary:         highlightC.Summary,
+			Title:           highlightC.Title,
+		}
+	} else {
+		item.Description.Highlight = model.Highlight{}
+	}
+}

--- a/mapper/search_mock.go
+++ b/mapper/search_mock.go
@@ -8,7 +8,24 @@ import (
 	zebedeeC "github.com/ONSdigital/dp-api-clients-go/v2/zebedee"
 )
 
-// GetMockSearchResponse get a mock search response in searchC.Response type
+// GetMockLegacySearchResponse get a mock search response in searchC.Response type from dp-search-api using ES 2.2
+func GetMockLegacySearchResponse() (searchC.Response, error) {
+	var respC searchC.Response
+
+	sampleResponse, err := ioutil.ReadFile("../mapper/data/mock_legacy_search_response.json")
+	if err != nil {
+		return searchC.Response{}, err
+	}
+
+	err = json.Unmarshal(sampleResponse, &respC)
+	if err != nil {
+		return searchC.Response{}, err
+	}
+
+	return respC, nil
+}
+
+// GetMockSearchResponse get a mock search response in searchC.Response type from dp-search-api using ES 7.10
 func GetMockSearchResponse() (searchC.Response, error) {
 	var respC searchC.Response
 

--- a/mapper/search_mock_test.go
+++ b/mapper/search_mock_test.go
@@ -15,11 +15,11 @@ var (
 	falsePointer = &falseValue
 )
 
-func TestUnitGetMockSearchResponseSuccess(t *testing.T) {
+func TestUnitGetMockLegacySearchResponse(t *testing.T) {
 	t.Parallel()
 
-	Convey("When GetMockSearchResponse is called", t, func() {
-		mockSearchResponse, err := GetMockSearchResponse()
+	Convey("When GetMockLegacySearchResponse is called", t, func() {
+		mockSearchResponse, err := GetMockLegacySearchResponse()
 
 		Convey("Then successfully get mock search response", func() {
 
@@ -32,7 +32,7 @@ func TestUnitGetMockSearchResponseSuccess(t *testing.T) {
 
 			mockSearchItems := []searchC.ContentItem{
 				{
-					Description: searchC.Description{
+					LegacyDescription: searchC.LegacyDescription{
 						Contact: &searchC.Contact{
 							Name:      "Name",
 							Telephone: "123",
@@ -111,6 +111,57 @@ func TestUnitGetMockSearchResponseSuccess(t *testing.T) {
 			}
 
 			So(mockSearchResponse, ShouldResemble, searchC.Response{
+				Count:        1,
+				ContentTypes: mockSearchContentTypes,
+				Items:        mockSearchItems,
+			})
+
+		})
+
+		Convey("And return no error", func() {
+			So(err, ShouldBeNil)
+		})
+	})
+}
+
+func TestUnitGetMockSearchResponse(t *testing.T) {
+	t.Parallel()
+
+	Convey("When GetMockSearchResponse is called", t, func() {
+		mockSearchResponse, err := GetMockSearchResponse()
+
+		Convey("Then successfully get mock search response", func() {
+
+			mockSearchContentTypes := []searchC.FilterCount{
+				{
+					Type:  "article",
+					Count: 1,
+				},
+			}
+
+			mockSearchDescription := searchC.Description{
+				Keywords:        []string{"regional house prices", "property prices", "area with cheapest houses", "area with most expensive houses"},
+				MetaDescription: "Test Meta Description",
+				ReleaseDate:     "2015-02-17T00:00:00.000Z",
+				Summary:         "Test Summary",
+				Title:           "Title Title",
+				Highlight: &searchC.Highlight{
+					Summary:  "Test Summary",
+					Title:    "Title Title",
+					Keywords: &[]string{"regional house prices", "property prices", "area with cheapest houses", "area with most expensive houses"},
+				},
+			}
+
+			mockSearchItems := []searchC.ContentItem{
+				{
+					Description: mockSearchDescription,
+					Type:        "article",
+					URI:         "/uri1/housing/articles/uri2/2015-02-17",
+				},
+			}
+
+			So(mockSearchResponse, ShouldResemble, searchC.Response{
+				ES_710:       true,
 				Count:        1,
 				ContentTypes: mockSearchContentTypes,
 				Items:        mockSearchItems,


### PR DESCRIPTION
## BLOCKED
- Need the following to be released
- `Search-API`
- `dp-api-clients-go`

### What
**Describe what you have changed and why.**
- Allow the controller to render the search data from `search-api` when it is using `ES 7.10`

### How to review
**Describe the steps required to test the changes.**
- Check if the changes make sense

### Who can review
**Describe who worked on the changes, so that other people can review.**
- Anyone