### PR TITLE
handle caching failure

### DIFF
--- a/cache/private/census_topic.go
+++ b/cache/private/census_topic.go
@@ -3,10 +3,10 @@ package private
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 
 	"github.com/ONSdigital/dp-frontend-search-controller/cache"
-	topicCliErr "github.com/ONSdigital/dp-topic-api/apierrors"
 	"github.com/ONSdigital/dp-topic-api/models"
 	topicCli "github.com/ONSdigital/dp-topic-api/sdk"
 	"github.com/ONSdigital/log.go/v2/log"
@@ -15,8 +15,9 @@ import (
 // UpdateCensusTopic is a function to update the census topic cache in publishing (private) mode.
 // This function talks to the dp-topic-api via its private endpoints to retrieve the census topic and its subtopic ids
 // The data returned by the dp-topic-api is of type *models.PrivateSubtopics which is then transformed in this function for the controller
-func UpdateCensusTopic(ctx context.Context, serviceAuthToken string, topicClient topicCli.Clienter) func() (*cache.Topic, error) {
-	return func() (*cache.Topic, error) {
+// If an error has occurred, this is captured in log.Error and then a nil *cache.Topic is returned
+func UpdateCensusTopic(ctx context.Context, serviceAuthToken string, topicClient topicCli.Clienter) func() *cache.Topic {
+	return func() *cache.Topic {
 		// get root topics from dp-topic-api
 		rootTopics, err := topicClient.GetRootTopicsPrivate(ctx, topicCli.Headers{ServiceAuthToken: serviceAuthToken})
 		if err != nil {
@@ -24,7 +25,7 @@ func UpdateCensusTopic(ctx context.Context, serviceAuthToken string, topicClient
 				"req_headers": topicCli.Headers{},
 			}
 			log.Error(ctx, "failed to get root topics from topic-api", err, logData)
-			return nil, err
+			return nil
 		}
 
 		//deference root topics items to allow ranging through them
@@ -34,7 +35,7 @@ func UpdateCensusTopic(ctx context.Context, serviceAuthToken string, topicClient
 		} else {
 			err := errors.New("root topic public items is nil")
 			log.Error(ctx, "failed to deference root topics items pointer", err)
-			return nil, err
+			return nil
 		}
 
 		var censusTopicCache *cache.Topic
@@ -52,10 +53,10 @@ func UpdateCensusTopic(ctx context.Context, serviceAuthToken string, topicClient
 		if censusTopicCache == nil {
 			err := errors.New("census root topic not found")
 			log.Error(ctx, "failed to get census topic to cache", err)
-			return nil, err
+			return nil
 		}
 
-		return censusTopicCache, nil
+		return censusTopicCache
 	}
 }
 
@@ -97,7 +98,7 @@ func getSubtopicsIDsPrivate(ctx context.Context, serviceAuthToken string, subtop
 	// get subtopics from dp-topic-api
 	subTopics, err := topicClient.GetSubtopicsPrivate(ctx, topicCliReqHeaders, topLevelTopicID)
 	if err != nil {
-		if err != topicCliErr.ErrNotFound {
+		if !strings.Contains(err.Error(), "404") {
 			logData := log.Data{
 				"req_headers":        topicCliReqHeaders,
 				"top_level_topic_id": topLevelTopicID,

--- a/cache/private/census_topic_test.go
+++ b/cache/private/census_topic_test.go
@@ -158,7 +158,7 @@ func TestUpdateCensusTopic(t *testing.T) {
 
 	Convey("Given census root topic does exist and has subtopics", t, func() {
 		Convey("When UpdateCensusTopic is called", func() {
-			respCensusTopicCache, err := UpdateCensusTopic(ctx, "", mockedTopicClient)()
+			respCensusTopicCache := UpdateCensusTopic(ctx, "", mockedTopicClient)()
 
 			Convey("Then the census topic cache is returned", func() {
 				So(respCensusTopicCache, ShouldNotBeNil)
@@ -169,10 +169,6 @@ func TestUpdateCensusTopic(t *testing.T) {
 				So(respCensusTopicCache.SubtopicsIDQuery, ShouldContainSubstring, testCensusSubTopicID1)
 				So(respCensusTopicCache.SubtopicsIDQuery, ShouldContainSubstring, testCensusSubTopicID2)
 				So(respCensusTopicCache.SubtopicsIDQuery, ShouldContainSubstring, testCensusSubSubTopicID)
-
-				Convey("And no error should be returned", func() {
-					So(err, ShouldBeNil)
-				})
 			})
 		})
 	})
@@ -185,14 +181,10 @@ func TestUpdateCensusTopic(t *testing.T) {
 		}
 
 		Convey("When UpdateCensusTopic is called", func() {
-			respCensusTopicCache, err := UpdateCensusTopic(ctx, "", failedRootTopicClient)()
+			respCensusTopicCache := UpdateCensusTopic(ctx, "", failedRootTopicClient)()
 
-			Convey("Then an error should be returned", func() {
-				So(err, ShouldNotBeNil)
-
-				Convey("And the census topic cache returned is nil", func() {
-					So(respCensusTopicCache, ShouldBeNil)
-				})
+			Convey("Then the census topic cache returned is nil", func() {
+				So(respCensusTopicCache, ShouldBeNil)
 			})
 		})
 	})
@@ -207,15 +199,10 @@ func TestUpdateCensusTopic(t *testing.T) {
 		}
 
 		Convey("When UpdateCensusTopic is called", func() {
-			respCensusTopicCache, err := UpdateCensusTopic(ctx, "", rootTopicsNilClient)()
+			respCensusTopicCache := UpdateCensusTopic(ctx, "", rootTopicsNilClient)()
 
-			Convey("Then an error should be returned", func() {
-				So(err, ShouldNotBeNil)
-				So(err.Error(), ShouldEqual, "root topic public items is nil")
-
-				Convey("And the census topic cache returned is nil", func() {
-					So(respCensusTopicCache, ShouldBeNil)
-				})
+			Convey("Then the census topic cache returned is nil", func() {
+				So(respCensusTopicCache, ShouldBeNil)
 			})
 		})
 	})
@@ -236,15 +223,10 @@ func TestUpdateCensusTopic(t *testing.T) {
 		}
 
 		Convey("When UpdateCensusTopicPrivate is called", func() {
-			respCensusTopicCache, err := UpdateCensusTopic(ctx, "", censusTopicNotExistClient)()
+			respCensusTopicCache := UpdateCensusTopic(ctx, "", censusTopicNotExistClient)()
 
-			Convey("Then an error should be returned", func() {
-				So(err, ShouldNotBeNil)
-				So(err.Error(), ShouldEqual, "census root topic not found")
-
-				Convey("And the census topic cache returned is nil", func() {
-					So(respCensusTopicCache, ShouldBeNil)
-				})
+			Convey("And the census topic cache returned is nil", func() {
+				So(respCensusTopicCache, ShouldBeNil)
 			})
 		})
 	})

--- a/cache/public/census_topic.go
+++ b/cache/public/census_topic.go
@@ -3,10 +3,10 @@ package public
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 
 	"github.com/ONSdigital/dp-frontend-search-controller/cache"
-	topicCliErr "github.com/ONSdigital/dp-topic-api/apierrors"
 	"github.com/ONSdigital/dp-topic-api/models"
 	topicCli "github.com/ONSdigital/dp-topic-api/sdk"
 	"github.com/ONSdigital/log.go/v2/log"
@@ -14,9 +14,10 @@ import (
 
 // UpdateCensusTopic is a function to update the census topic cache in web (public) mode.
 // This function talks to the dp-topic-api via its public endpoints to retrieve the census topic and its subtopic ids
-// The data returned by the dp-topic-api is of type *models.PublicSubtopics which is then transformed in this function for the controller
-func UpdateCensusTopic(ctx context.Context, topicClient topicCli.Clienter) func() (*cache.Topic, error) {
-	return func() (*cache.Topic, error) {
+// The data returned by the dp-topic-api is of type *models.PublicSubtopics which is then transformed to *cache.Topic in this function for the controller
+// If an error has occurred, this is captured in log.Error and then a nil *cache.Topic is returned
+func UpdateCensusTopic(ctx context.Context, topicClient topicCli.Clienter) func() *cache.Topic {
+	return func() *cache.Topic {
 		// get root topics from dp-topic-api
 		rootTopics, err := topicClient.GetRootTopicsPublic(ctx, topicCli.Headers{})
 		if err != nil {
@@ -24,14 +25,14 @@ func UpdateCensusTopic(ctx context.Context, topicClient topicCli.Clienter) func(
 				"req_headers": topicCli.Headers{},
 			}
 			log.Error(ctx, "failed to get root topics from topic-api", err, logData)
-			return nil, err
+			return nil
 		}
 
 		//deference root topics items to allow ranging through them
 		if rootTopics.PublicItems == nil {
 			err := errors.New("root topic public items is nil")
 			log.Error(ctx, "failed to deference root topics items pointer", err)
-			return nil, err
+			return nil
 		}
 		rootTopicItems := *rootTopics.PublicItems
 
@@ -50,10 +51,10 @@ func UpdateCensusTopic(ctx context.Context, topicClient topicCli.Clienter) func(
 		if censusTopicCache == nil {
 			err := errors.New("census root topic not found")
 			log.Error(ctx, "failed to get census topic to cache", err)
-			return nil, err
+			return nil
 		}
 
-		return censusTopicCache, nil
+		return censusTopicCache
 	}
 }
 
@@ -95,7 +96,7 @@ func getSubtopicsIDsPublic(ctx context.Context, subtopicsIDChan chan string, top
 	// get subtopics from dp-topic-api
 	subTopics, err := topicClient.GetSubtopicsPublic(ctx, topicCli.Headers{}, topLevelTopicID)
 	if err != nil {
-		if err != topicCliErr.ErrNotFound {
+		if !strings.Contains(err.Error(), "404") {
 			logData := log.Data{
 				"req_headers":        topicCli.Headers{},
 				"top_level_topic_id": topLevelTopicID,

--- a/cache/public/census_topic_test.go
+++ b/cache/public/census_topic_test.go
@@ -126,7 +126,7 @@ func TestUpdateCensusTopic(t *testing.T) {
 
 	Convey("Given census root topic does exist and has subtopics", t, func() {
 		Convey("When UpdateCensusTopic is called", func() {
-			respCensusTopicCache, err := UpdateCensusTopic(ctx, mockedTopicClient)()
+			respCensusTopicCache := UpdateCensusTopic(ctx, mockedTopicClient)()
 
 			Convey("Then the census topic cache is returned", func() {
 				So(respCensusTopicCache, ShouldNotBeNil)
@@ -137,10 +137,6 @@ func TestUpdateCensusTopic(t *testing.T) {
 				So(respCensusTopicCache.SubtopicsIDQuery, ShouldContainSubstring, testCensusSubTopicID1)
 				So(respCensusTopicCache.SubtopicsIDQuery, ShouldContainSubstring, testCensusSubTopicID2)
 				So(respCensusTopicCache.SubtopicsIDQuery, ShouldContainSubstring, testCensusSubSubTopicID)
-
-				Convey("And no error should be returned", func() {
-					So(err, ShouldBeNil)
-				})
 			})
 		})
 	})
@@ -153,14 +149,10 @@ func TestUpdateCensusTopic(t *testing.T) {
 		}
 
 		Convey("When UpdateCensusTopic is called", func() {
-			respCensusTopicCache, err := UpdateCensusTopic(ctx, failedRootTopicClient)()
+			respCensusTopicCache := UpdateCensusTopic(ctx, failedRootTopicClient)()
 
-			Convey("Then an error should be returned", func() {
-				So(err, ShouldNotBeNil)
-
-				Convey("And the census topic cache returned is nil", func() {
-					So(respCensusTopicCache, ShouldBeNil)
-				})
+			Convey("Then the census topic cache returned is nil", func() {
+				So(respCensusTopicCache, ShouldBeNil)
 			})
 		})
 	})
@@ -175,15 +167,10 @@ func TestUpdateCensusTopic(t *testing.T) {
 		}
 
 		Convey("When UpdateCensusTopic is called", func() {
-			respCensusTopicCache, err := UpdateCensusTopic(ctx, rootTopicsNilClient)()
+			respCensusTopicCache := UpdateCensusTopic(ctx, rootTopicsNilClient)()
 
-			Convey("Then an error should be returned", func() {
-				So(err, ShouldNotBeNil)
-				So(err.Error(), ShouldEqual, "root topic public items is nil")
-
-				Convey("And the census topic cache returned is nil", func() {
-					So(respCensusTopicCache, ShouldBeNil)
-				})
+			Convey("Then the census topic cache returned is nil", func() {
+				So(respCensusTopicCache, ShouldBeNil)
 			})
 		})
 	})
@@ -204,15 +191,10 @@ func TestUpdateCensusTopic(t *testing.T) {
 		}
 
 		Convey("When UpdateCensusTopic is called", func() {
-			respCensusTopicCache, err := UpdateCensusTopic(ctx, censusTopicNotExistClient)()
+			respCensusTopicCache := UpdateCensusTopic(ctx, censusTopicNotExistClient)()
 
-			Convey("Then an error should be returned", func() {
-				So(err, ShouldNotBeNil)
-				So(err.Error(), ShouldEqual, "census root topic not found")
-
-				Convey("And the census topic cache returned is nil", func() {
-					So(respCensusTopicCache, ShouldBeNil)
-				})
+			Convey("Then the census topic cache returned is nil", func() {
+				So(respCensusTopicCache, ShouldBeNil)
 			})
 		})
 	})

--- a/cache/topic.go
+++ b/cache/topic.go
@@ -45,8 +45,9 @@ func NewTopicCache(ctx context.Context, updateInterval *time.Duration) (*TopicCa
 
 // AddUpdateFunc adds an update function to the topic cache for a topic with the `title` passed to the function
 // This update function will then be triggered once or at every fixed interval as per the prior setup of the TopicCache
-func (dc *TopicCache) AddUpdateFunc(title string, updateFunc func() (*Topic, error)) {
+func (dc *TopicCache) AddUpdateFunc(title string, updateFunc func() *Topic) {
 	dc.UpdateFuncs[title] = func() (interface{}, error) {
-		return updateFunc()
+		// error handling is done within the updateFunc
+		return updateFunc(), nil
 	}
 }

--- a/cache/topic_test.go
+++ b/cache/topic_test.go
@@ -68,12 +68,12 @@ func TestAddUpdateFunc(t *testing.T) {
 		mockTopicCache, err := NewTopicCache(ctx, nil)
 		So(err, ShouldBeNil)
 
-		topicUpdateFunc := func() (*Topic, error) {
+		topicUpdateFunc := func() *Topic {
 			return &Topic{
 				ID:               "test",
 				LocaliseKeyName:  "Test",
 				SubtopicsIDQuery: "2453,1232",
-			}, nil
+			}
 		}
 
 		Convey("When AddUpdateFunc is called", func() {


### PR DESCRIPTION
### What
**Describe what you have changed and why.**
- Handle caching failure
- We don't want to stop the service if the caching fails. If caching fails, then the error is logged and then it tries again at its next update interval
- Reduce logging for caching
- If a subtopic is not found, then this logs as an error but with regards to caching, not finding a subtopic is completely acceptable and not considered an error

### How to review
**Describe the steps required to test the changes.**
- Check if the code changes make sense
- Check if the test passes

### Who can review
**Describe who worked on the changes, so that other people can review.**
- Anyone