### PR TITLE
render topic filters with new topic model

### DIFF
--- a/assets/templates/partials/filter.tmpl
+++ b/assets/templates/partials/filter.tmpl
@@ -15,7 +15,7 @@
                     <span class="ons-checkbox ons-checkbox--no-border category-filter">
                         <input type="checkbox" id="topic-group-{{ $index }}"
                             class="ons-checkbox__input ons-js-checkbox"
-                            value="{{ print $topFilter.FilterKey }}" categoryChildren="{{ print $topFilter.FilterKey }}" aria-controls="topic-group-{{ $index }}-other-wrap"
+                            value="{{ print $topFilter.Query }}"
                             aria-haspopup="true"
                             data-gtm-label="{{ $topFilter.LocaliseKeyName }}"
                             {{ if $topFilter.IsChecked }}
@@ -26,31 +26,6 @@
                         <label class="ons-checkbox__label" for="topic-group-{{ $index }}" id="topic-group-{{ $index }}-label">
                             {{ localise $topFilter.LocaliseKeyName $lang 4 }} ({{ $topFilter.NumberOfResults }})
                         </label>
-                        <span class="ons-checkbox__other" id="topic-group-{{ $index }}-other-wrap">
-                            <fieldset class="ons-fieldset ons-js-other-fieldset">
-                                {{ range $index, $childFilter := $topFilter.Types }}
-                                    {{ $id := index $childFilter.FilterKey 0 }}
-                                    <div class="ons-checkboxes__items">
-                                        <span class="ons-checkboxes__item ons-checkboxes__item--no-border">
-                                            <span class="ons-checkbox ons-checkbox--no-border child-filter">
-                                                <input id="{{ $id }}"
-                                                    class="ons-checkbox__input ons-js-checkbox"
-                                                    type="checkbox" name="filter"
-                                                    {{ if $childFilter.IsChecked }}checked{{end}}
-                                                    data-gtm-label="{{ $childFilter.LocaliseKeyName }}"
-                                                    value="{{ $id }}"
-                                                    {{ if eq $childFilter.NumberOfResults 0 }} disabled aria-disabled="true" {{ end }}
-                                                />
-                                                <label class="ons-checkbox__label" for="{{ $id }}"
-                                                    id="{{ $id }}-label">
-                                                    {{ localise $childFilter.LocaliseKeyName $lang 4 }} ({{ $childFilter.NumberOfResults }})
-                                                </label>
-                                            </span>
-                                        </span>
-                                    </div>
-                                {{ end }}
-                            </fieldset>
-                        </span>
                     </span>
                 </span>
             </div>

--- a/cache/private/census_topic.go
+++ b/cache/private/census_topic.go
@@ -15,7 +15,7 @@ import (
 // UpdateCensusTopic is a function to update the census topic cache in publishing (private) mode.
 // This function talks to the dp-topic-api via its private endpoints to retrieve the census topic and its subtopic ids
 // The data returned by the dp-topic-api is of type *models.PrivateSubtopics which is then transformed in this function for the controller
-// If an error has occurred, this is captured in log.Error and then a nil *cache.Topic is returned
+// If an error has occurred, this is captured in log.Error and then an empty census topic is returned
 func UpdateCensusTopic(ctx context.Context, serviceAuthToken string, topicClient topicCli.Clienter) func() *cache.Topic {
 	return func() *cache.Topic {
 		// get root topics from dp-topic-api
@@ -25,7 +25,7 @@ func UpdateCensusTopic(ctx context.Context, serviceAuthToken string, topicClient
 				"req_headers": topicCli.Headers{},
 			}
 			log.Error(ctx, "failed to get root topics from topic-api", err, logData)
-			return nil
+			return cache.GetEmptyCensusTopic()
 		}
 
 		//deference root topics items to allow ranging through them
@@ -35,7 +35,7 @@ func UpdateCensusTopic(ctx context.Context, serviceAuthToken string, topicClient
 		} else {
 			err := errors.New("root topic public items is nil")
 			log.Error(ctx, "failed to deference root topics items pointer", err)
-			return nil
+			return cache.GetEmptyCensusTopic()
 		}
 
 		var censusTopicCache *cache.Topic
@@ -53,7 +53,7 @@ func UpdateCensusTopic(ctx context.Context, serviceAuthToken string, topicClient
 		if censusTopicCache == nil {
 			err := errors.New("census root topic not found")
 			log.Error(ctx, "failed to get census topic to cache", err)
-			return nil
+			return cache.GetEmptyCensusTopic()
 		}
 
 		return censusTopicCache

--- a/cache/private/census_topic_test.go
+++ b/cache/private/census_topic_test.go
@@ -183,8 +183,8 @@ func TestUpdateCensusTopic(t *testing.T) {
 		Convey("When UpdateCensusTopic is called", func() {
 			respCensusTopicCache := UpdateCensusTopic(ctx, "", failedRootTopicClient)()
 
-			Convey("Then the census topic cache returned is nil", func() {
-				So(respCensusTopicCache, ShouldBeNil)
+			Convey("Then an empty census topic cache should be returned", func() {
+				So(respCensusTopicCache, ShouldResemble, cache.GetEmptyCensusTopic())
 			})
 		})
 	})
@@ -201,8 +201,8 @@ func TestUpdateCensusTopic(t *testing.T) {
 		Convey("When UpdateCensusTopic is called", func() {
 			respCensusTopicCache := UpdateCensusTopic(ctx, "", rootTopicsNilClient)()
 
-			Convey("Then the census topic cache returned is nil", func() {
-				So(respCensusTopicCache, ShouldBeNil)
+			Convey("Then an empty census topic cache should be returned", func() {
+				So(respCensusTopicCache, ShouldResemble, cache.GetEmptyCensusTopic())
 			})
 		})
 	})
@@ -225,8 +225,8 @@ func TestUpdateCensusTopic(t *testing.T) {
 		Convey("When UpdateCensusTopicPrivate is called", func() {
 			respCensusTopicCache := UpdateCensusTopic(ctx, "", censusTopicNotExistClient)()
 
-			Convey("And the census topic cache returned is nil", func() {
-				So(respCensusTopicCache, ShouldBeNil)
+			Convey("Then an empty census topic cache should be returned", func() {
+				So(respCensusTopicCache, ShouldResemble, cache.GetEmptyCensusTopic())
 			})
 		})
 	})

--- a/cache/public/census_topic.go
+++ b/cache/public/census_topic.go
@@ -15,7 +15,7 @@ import (
 // UpdateCensusTopic is a function to update the census topic cache in web (public) mode.
 // This function talks to the dp-topic-api via its public endpoints to retrieve the census topic and its subtopic ids
 // The data returned by the dp-topic-api is of type *models.PublicSubtopics which is then transformed to *cache.Topic in this function for the controller
-// If an error has occurred, this is captured in log.Error and then a nil *cache.Topic is returned
+// If an error has occurred, this is captured in log.Error and then an empty census topic is returned
 func UpdateCensusTopic(ctx context.Context, topicClient topicCli.Clienter) func() *cache.Topic {
 	return func() *cache.Topic {
 		// get root topics from dp-topic-api
@@ -25,14 +25,14 @@ func UpdateCensusTopic(ctx context.Context, topicClient topicCli.Clienter) func(
 				"req_headers": topicCli.Headers{},
 			}
 			log.Error(ctx, "failed to get root topics from topic-api", err, logData)
-			return nil
+			return cache.GetEmptyCensusTopic()
 		}
 
 		//deference root topics items to allow ranging through them
 		if rootTopics.PublicItems == nil {
 			err := errors.New("root topic public items is nil")
 			log.Error(ctx, "failed to deference root topics items pointer", err)
-			return nil
+			return cache.GetEmptyCensusTopic()
 		}
 		rootTopicItems := *rootTopics.PublicItems
 
@@ -51,7 +51,7 @@ func UpdateCensusTopic(ctx context.Context, topicClient topicCli.Clienter) func(
 		if censusTopicCache == nil {
 			err := errors.New("census root topic not found")
 			log.Error(ctx, "failed to get census topic to cache", err)
-			return nil
+			return cache.GetEmptyCensusTopic()
 		}
 
 		return censusTopicCache

--- a/cache/public/census_topic_test.go
+++ b/cache/public/census_topic_test.go
@@ -151,8 +151,8 @@ func TestUpdateCensusTopic(t *testing.T) {
 		Convey("When UpdateCensusTopic is called", func() {
 			respCensusTopicCache := UpdateCensusTopic(ctx, failedRootTopicClient)()
 
-			Convey("Then the census topic cache returned is nil", func() {
-				So(respCensusTopicCache, ShouldBeNil)
+			Convey("Then an empty census topic cache should be returned", func() {
+				So(respCensusTopicCache, ShouldResemble, cache.GetEmptyCensusTopic())
 			})
 		})
 	})
@@ -169,8 +169,8 @@ func TestUpdateCensusTopic(t *testing.T) {
 		Convey("When UpdateCensusTopic is called", func() {
 			respCensusTopicCache := UpdateCensusTopic(ctx, rootTopicsNilClient)()
 
-			Convey("Then the census topic cache returned is nil", func() {
-				So(respCensusTopicCache, ShouldBeNil)
+			Convey("Then an empty census topic cache should be returned", func() {
+				So(respCensusTopicCache, ShouldResemble, cache.GetEmptyCensusTopic())
 			})
 		})
 	})
@@ -193,8 +193,8 @@ func TestUpdateCensusTopic(t *testing.T) {
 		Convey("When UpdateCensusTopic is called", func() {
 			respCensusTopicCache := UpdateCensusTopic(ctx, censusTopicNotExistClient)()
 
-			Convey("Then the census topic cache returned is nil", func() {
-				So(respCensusTopicCache, ShouldBeNil)
+			Convey("Then an empty census topic cache should be returned", func() {
+				So(respCensusTopicCache, ShouldResemble, cache.GetEmptyCensusTopic())
 			})
 		})
 	})

--- a/cache/topic.go
+++ b/cache/topic.go
@@ -96,7 +96,7 @@ func (dc *TopicCache) GetCensusData(ctx context.Context) (*Topic, error) {
 // GetEmptyCensusTopic returns an empty census topic cache in the event when updating the cache of the census topic fails
 func GetEmptyCensusTopic() *Topic {
 	return &Topic{
-		LocaliseKeyName: "Census",
+		LocaliseKeyName: CensusTopicTitle,
 		List:            NewSubTopicsMap(),
 	}
 }

--- a/cache/topic.go
+++ b/cache/topic.go
@@ -71,6 +71,15 @@ func (dc *TopicCache) GetData(ctx context.Context, key string) (*Topic, error) {
 	return topicCacheData, nil
 }
 
+// AddUpdateFunc adds an update function to the topic cache for a topic with the `title` passed to the function
+// This update function will then be triggered once or at every fixed interval as per the prior setup of the TopicCache
+func (dc *TopicCache) AddUpdateFunc(title string, updateFunc func() *Topic) {
+	dc.UpdateFuncs[title] = func() (interface{}, error) {
+		// error handling is done within the updateFunc
+		return updateFunc(), nil
+	}
+}
+
 func (dc *TopicCache) GetCensusData(ctx context.Context) (*Topic, error) {
 	censusTopicCache, err := dc.GetData(ctx, CensusTopicTitle)
 	if err != nil {
@@ -84,11 +93,10 @@ func (dc *TopicCache) GetCensusData(ctx context.Context) (*Topic, error) {
 	return censusTopicCache, nil
 }
 
-// AddUpdateFunc adds an update function to the topic cache for a topic with the `title` passed to the function
-// This update function will then be triggered once or at every fixed interval as per the prior setup of the TopicCache
-func (dc *TopicCache) AddUpdateFunc(title string, updateFunc func() *Topic) {
-	dc.UpdateFuncs[title] = func() (interface{}, error) {
-		// error handling is done within the updateFunc
-		return updateFunc(), nil
+// GetEmptyCensusTopic returns an empty census topic cache in the event when updating the cache of the census topic fails
+func GetEmptyCensusTopic() *Topic {
+	return &Topic{
+		LocaliseKeyName: "Census",
+		List:            NewSubTopicsMap(),
 	}
 }

--- a/cache/topic_test.go
+++ b/cache/topic_test.go
@@ -209,3 +209,18 @@ func TestAddUpdateFunc(t *testing.T) {
 		})
 	})
 }
+
+func TestGetEmptyCensusTopic(t *testing.T) {
+	t.Parallel()
+
+	Convey("When GetEmptyCensusTopic is called", t, func() {
+		emptyCensusTopic := GetEmptyCensusTopic()
+
+		Convey("Then an empty census topic should be returned", func() {
+			So(emptyCensusTopic.ID, ShouldEqual, "")
+			So(emptyCensusTopic.LocaliseKeyName, ShouldEqual, CensusTopicTitle)
+			So(emptyCensusTopic.Query, ShouldEqual, "")
+			So(emptyCensusTopic.List, ShouldNotBeNil)
+		})
+	})
+}


### PR DESCRIPTION
### What
**Describe what you have changed and why.**
- Render topic filters with new topic model
- Return an empty census topic object when there is a failure in updating the cache for the census topic. If we pass `nil`, it will error when trying to access that object

### How to review
**Describe the steps required to test the changes.**
- Check if the changes make sense

### Who can review
**Describe who worked on the changes, so that other people can review.**
- Anyone