### PR TITLE
update handling of topic filter

### DIFF
--- a/apperrors/errors.go
+++ b/apperrors/errors.go
@@ -5,18 +5,26 @@ import (
 )
 
 var (
-	ErrInvalidFilter         = errors.New("invalid filter type given")
 	ErrFilterNotFound        = errors.New("filter type from client not available in data.go")
 	ErrInternalServer        = errors.New("internal server error")
+	ErrInvalidFilter         = errors.New("invalid filter type given")
 	ErrInvalidPage           = errors.New("invalid page value, exceeding the default maximum search results")
-	ErrPageExceedsTotalPages = errors.New("invalid page value, exceeding the total page value")
 	ErrInvalidQueryString    = errors.New("the query string did not meet requirements")
+	ErrPageExceedsTotalPages = errors.New("invalid page value, exceeding the total page value")
+	ErrTopicNotFound         = errors.New("topic not found")
 
 	BadRequestMap = map[error]bool{
+		ErrFilterNotFound:        true,
 		ErrInvalidFilter:         true,
 		ErrInvalidPage:           true,
-		ErrFilterNotFound:        true,
 		ErrPageExceedsTotalPages: true,
 		ErrInvalidQueryString:    true,
+		ErrTopicNotFound:         true,
+	}
+
+	// ErrMapForRenderBeforeAPICalls is a list of errors which leads to the search page being rendered before making any API calls
+	ErrMapForRenderBeforeAPICalls = map[error]bool{
+		ErrInvalidQueryString: true,
+		ErrTopicNotFound:      true,
 	}
 )

--- a/assets/templates/partials/filter.tmpl
+++ b/assets/templates/partials/filter.tmpl
@@ -9,22 +9,22 @@
     <input type="hidden" name="q" value="{{ $query }}"/>
     <input type="hidden" name="sort" value="{{$sort}}"/>
     <fieldset class="ons-fieldset">
-        {{ range $index, $topFilter := $topicFilters }}
+        {{ range $index, $topicFilter := $topicFilters }}
             <div class="ons-checkboxes__items">
                 <span class="ons-checkboxes__item ons-checkboxes__item--no-border">
-                    <span class="ons-checkbox ons-checkbox--no-border category-filter">
+                    <span class="ons-checkbox ons-checkbox--no-border topic-filter">
                         <input type="checkbox" id="topic-group-{{ $index }}"
                             class="ons-checkbox__input ons-js-checkbox"
-                            value="{{ print $topFilter.Query }}"
-                            aria-haspopup="true"
-                            data-gtm-label="{{ $topFilter.LocaliseKeyName }}"
-                            {{ if $topFilter.IsChecked }}
+                            name="topics"
+                            value="{{ print $topicFilter.Query }}"
+                            data-gtm-label="{{ $topicFilter.LocaliseKeyName }}"
+                            {{ if $topicFilter.IsChecked }}
                                 checked
                             {{ end }}
-                            {{ if eq $topFilter.NumberOfResults 0 }} disabled aria-disabled="true" {{ end }}
+                            {{ if eq $topicFilter.NumberOfResults 0 }} disabled aria-disabled="true" {{ end }}
                         >
                         <label class="ons-checkbox__label" for="topic-group-{{ $index }}" id="topic-group-{{ $index }}-label">
-                            {{ localise $topFilter.LocaliseKeyName $lang 4 }} ({{ $topFilter.NumberOfResults }})
+                            {{ localise $topicFilter.LocaliseKeyName $lang 4 }} ({{ $topicFilter.NumberOfResults }})
                         </label>
                     </span>
                 </span>
@@ -61,7 +61,7 @@
             {{ range $index, $topFilter := $filters}}
                 <div class="ons-checkboxes__items">
                     <span class="ons-checkboxes__item ons-checkboxes__item--no-border">
-                        <span class="ons-checkbox ons-checkbox--no-border category-filter">
+                        <span class="ons-checkbox ons-checkbox--no-border content-type-filter">
                             <input type="checkbox" id="group-{{ $index }}"
                                 class="ons-checkbox__input ons-js-checkbox"
                                 value="{{ print $topFilter.FilterKey }}" categoryChildren="{{ print $topFilter.FilterKey }}" aria-controls="group-{{ $index }}-other-wrap"

--- a/cache/mock.go
+++ b/cache/mock.go
@@ -10,7 +10,7 @@ func GetMockCensusTopicCacheList(ctx context.Context) (*CacheList, error) {
 		return nil, err
 	}
 
-	testCensusTopicCache.Set("Census", GetMockCensusTopic())
+	testCensusTopicCache.Set(CensusTopicID, GetMockCensusTopic())
 
 	cacheList := CacheList{
 		CensusTopic: testCensusTopicCache,
@@ -22,8 +22,8 @@ func GetMockCensusTopicCacheList(ctx context.Context) (*CacheList, error) {
 // GetMockCensusTopic returns a mocked Cenus topic which contains all the information for the mock census topic
 func GetMockCensusTopic() *Topic {
 	mockCensusTopic := &Topic{
-		ID:              "1234",
-		LocaliseKeyName: CensusTopicTitle,
+		ID:              CensusTopicID,
+		LocaliseKeyName: "Census",
 		Query:           "1234,5678",
 	}
 

--- a/cache/mock_test.go
+++ b/cache/mock_test.go
@@ -36,8 +36,8 @@ func TestGetMockCensusTopic(t *testing.T) {
 
 		Convey("Then the mock census topic is returned", func() {
 			So(mockCensusTopic, ShouldNotBeNil)
-			So(mockCensusTopic.ID, ShouldEqual, "1234")
-			So(mockCensusTopic.LocaliseKeyName, ShouldEqual, CensusTopicTitle)
+			So(mockCensusTopic.ID, ShouldEqual, CensusTopicID)
+			So(mockCensusTopic.LocaliseKeyName, ShouldEqual, "Census")
 			So(mockCensusTopic.Query, ShouldEqual, "1234,5678")
 			So(mockCensusTopic.List.Get("1234"), ShouldBeTrue)
 			So(mockCensusTopic.List.Get("5678"), ShouldBeTrue)

--- a/cache/private/census_topic.go
+++ b/cache/private/census_topic.go
@@ -42,7 +42,7 @@ func UpdateCensusTopic(ctx context.Context, serviceAuthToken string, topicClient
 
 		// go through each root topic, find census topic and gets its data for caching which includes subtopic ids
 		for i := range rootTopicItems {
-			if rootTopicItems[i].Current.Title == cache.CensusTopicTitle {
+			if rootTopicItems[i].Current.ID == cache.CensusTopicID {
 				subtopicsIDChan := make(chan string)
 
 				censusTopicCache = getRootTopicCachePrivate(ctx, serviceAuthToken, subtopicsIDChan, topicClient, *rootTopicItems[i].Current)

--- a/cache/private/census_topic_test.go
+++ b/cache/private/census_topic_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 const (
-	testCensusTopicID       = "1234"
 	testCensusTitle         = "Census"
 	testCensusSubTopicID1   = "5678"
 	testCensusSubTopicID2   = "1235"
@@ -33,7 +32,7 @@ var (
 	}
 
 	testCensusRootTopicPrivate = models.TopicResponse{
-		ID:      testCensusTopicID,
+		ID:      cache.CensusTopicID,
 		Next:    &testCensusRootTopic,
 		Current: &testCensusRootTopic,
 	}
@@ -83,7 +82,7 @@ var (
 
 var (
 	testCensusRootTopic = models.Topic{
-		ID:          testCensusTopicID,
+		ID:          cache.CensusTopicID,
 		Title:       testCensusTitle,
 		SubtopicIds: []string{"5678", "1235"},
 	}
@@ -113,7 +112,7 @@ var (
 	}
 
 	expectedCensusTopicCache = &cache.Topic{
-		ID:              testCensusTopicID,
+		ID:              cache.CensusTopicID,
 		LocaliseKeyName: testCensusTitle,
 		Query:           fmt.Sprintf("%s,%s,%s", testCensusSubTopicID1, testCensusSubTopicID2, testCensusSubSubTopicID),
 	}
@@ -146,7 +145,7 @@ func TestUpdateCensusTopic(t *testing.T) {
 
 		GetSubtopicsPrivateFunc: func(ctx context.Context, reqHeaders sdk.Headers, id string) (*models.PrivateSubtopics, error) {
 			switch id {
-			case testCensusTopicID:
+			case cache.CensusTopicID:
 				return testCensusSubTopicsPrivate, nil
 			case testCensusSubTopicID1:
 				return testCensusSubTopic1SubTopicsPrivate, nil
@@ -242,7 +241,7 @@ func TestGetRootTopicCachePrivate(t *testing.T) {
 	mockedTopicClient := &mockTopic.ClienterMock{
 		GetSubtopicsPrivateFunc: func(ctx context.Context, reqHeaders sdk.Headers, id string) (*models.PrivateSubtopics, error) {
 			switch id {
-			case testCensusTopicID:
+			case cache.CensusTopicID:
 				return testCensusSubTopicsPrivate, nil
 			case testCensusSubTopicID1:
 				return testCensusSubTopic1SubTopicsPrivate, nil
@@ -278,7 +277,7 @@ func TestGetSubtopicsIDsPrivate(t *testing.T) {
 	mockedTopicClient := &mockTopic.ClienterMock{
 		GetSubtopicsPrivateFunc: func(ctx context.Context, reqHeaders sdk.Headers, id string) (*models.PrivateSubtopics, error) {
 			switch id {
-			case testCensusTopicID:
+			case cache.CensusTopicID:
 				return testCensusSubTopicsPrivate, nil
 			case testCensusSubTopicID1:
 				return testCensusSubTopic1SubTopicsPrivate, nil
@@ -294,7 +293,7 @@ func TestGetSubtopicsIDsPrivate(t *testing.T) {
 		subtopicsIDChan := make(chan string)
 
 		Convey("When getSubtopicsIDsPrivate is called", func() {
-			subTopicsIDQuery := mockGetSubtopicsIDsPrivate(ctx, subtopicsIDChan, mockedTopicClient, testCensusTopicID)
+			subTopicsIDQuery := mockGetSubtopicsIDsPrivate(ctx, subtopicsIDChan, mockedTopicClient, cache.CensusTopicID)
 
 			Convey("Then subtopic ids should be sent to subtopicsIDChan channel", func() {
 				So(subTopicsIDQuery, ShouldNotBeEmpty)
@@ -328,11 +327,11 @@ func TestGetSubtopicsIDsPrivate(t *testing.T) {
 		}
 
 		Convey("When getSubtopicsIDsPrivate is called", func() {
-			subTopicsIDQuery := mockGetSubtopicsIDsPrivate(ctx, subtopicsIDChan, failedGetSubtopicClient, testCensusTopicID)
+			subTopicsIDQuery := mockGetSubtopicsIDsPrivate(ctx, subtopicsIDChan, failedGetSubtopicClient, cache.CensusTopicID)
 
 			Convey("Then no subtopic ids should be sent to subtopicsIDChan channel", func() {
 				// the query only contains the root topic id and no subtopic ids
-				So(subTopicsIDQuery, ShouldEqual, testCensusTopicID)
+				So(subTopicsIDQuery, ShouldEqual, cache.CensusTopicID)
 			})
 		})
 	})
@@ -349,11 +348,11 @@ func TestGetSubtopicsIDsPrivate(t *testing.T) {
 		}
 
 		Convey("When getSubtopicsIDsPrivate is called", func() {
-			subTopicsIDQuery := mockGetSubtopicsIDsPrivate(ctx, subtopicsIDChan, subtopicItemsNilClient, testCensusTopicID)
+			subTopicsIDQuery := mockGetSubtopicsIDsPrivate(ctx, subtopicsIDChan, subtopicItemsNilClient, cache.CensusTopicID)
 
 			Convey("Then no subtopic ids should be sent to subtopicsIDChan channel", func() {
 				// the query only contains the root topic id and no subtopic ids
-				So(subTopicsIDQuery, ShouldEqual, testCensusTopicID)
+				So(subTopicsIDQuery, ShouldEqual, cache.CensusTopicID)
 			})
 		})
 	})

--- a/cache/public/census_topic.go
+++ b/cache/public/census_topic.go
@@ -40,7 +40,7 @@ func UpdateCensusTopic(ctx context.Context, topicClient topicCli.Clienter) func(
 
 		// go through each root topic, find census topic and gets its data for caching which includes subtopic ids
 		for i := range rootTopicItems {
-			if rootTopicItems[i].Title == cache.CensusTopicTitle {
+			if rootTopicItems[i].ID == cache.CensusTopicID {
 				subtopicsIDChan := make(chan string)
 
 				censusTopicCache = getRootTopicCachePublic(ctx, subtopicsIDChan, topicClient, rootTopicItems[i])

--- a/cache/public/census_topic_test.go
+++ b/cache/public/census_topic_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 const (
-	testCensusTopicID       = "1234"
 	testCensusTitle         = "Census"
 	testCensusSubTopicID1   = "5678"
 	testCensusSubTopicID2   = "1235"
@@ -33,7 +32,7 @@ var (
 	}
 
 	testCensusRootTopic = models.Topic{
-		ID:          testCensusTopicID,
+		ID:          cache.CensusTopicID,
 		Title:       testCensusTitle,
 		SubtopicIds: []string{"5678", "1235"},
 	}
@@ -81,7 +80,7 @@ var (
 	}
 
 	expectedCensusTopicCache = &cache.Topic{
-		ID:              testCensusTopicID,
+		ID:              cache.CensusTopicID,
 		LocaliseKeyName: testCensusTitle,
 		Query:           fmt.Sprintf("%s,%s,%s", testCensusSubTopicID1, testCensusSubTopicID2, testCensusSubSubTopicID),
 	}
@@ -114,7 +113,7 @@ func TestUpdateCensusTopic(t *testing.T) {
 
 		GetSubtopicsPublicFunc: func(ctx context.Context, reqHeaders sdk.Headers, id string) (*models.PublicSubtopics, error) {
 			switch id {
-			case testCensusTopicID:
+			case cache.CensusTopicID:
 				return testCensusSubTopics, nil
 			case testCensusSubTopicID1:
 				return testCensusSubTopic1SubTopics, nil
@@ -210,7 +209,7 @@ func TestGetRootTopicCachePublic(t *testing.T) {
 	mockedTopicClient := &mockTopicCli.ClienterMock{
 		GetSubtopicsPublicFunc: func(ctx context.Context, reqHeaders sdk.Headers, id string) (*models.PublicSubtopics, error) {
 			switch id {
-			case testCensusTopicID:
+			case cache.CensusTopicID:
 				return testCensusSubTopics, nil
 			case testCensusSubTopicID1:
 				return testCensusSubTopic1SubTopics, nil
@@ -246,7 +245,7 @@ func TestGetSubtopicsIDsPublic(t *testing.T) {
 	mockedTopicClient := &mockTopicCli.ClienterMock{
 		GetSubtopicsPublicFunc: func(ctx context.Context, reqHeaders sdk.Headers, id string) (*models.PublicSubtopics, error) {
 			switch id {
-			case testCensusTopicID:
+			case cache.CensusTopicID:
 				return testCensusSubTopics, nil
 			case testCensusSubTopicID1:
 				return testCensusSubTopic1SubTopics, nil
@@ -262,7 +261,7 @@ func TestGetSubtopicsIDsPublic(t *testing.T) {
 		subtopicsIDChan := make(chan string)
 
 		Convey("When getSubtopicsIDsPublic is called", func() {
-			subTopicsIDQuery := mockGetSubtopicsIDsPublic(ctx, subtopicsIDChan, mockedTopicClient, testCensusTopicID)
+			subTopicsIDQuery := mockGetSubtopicsIDsPublic(ctx, subtopicsIDChan, mockedTopicClient, cache.CensusTopicID)
 
 			Convey("Then subtopic ids should be sent to subtopicsIDChan channel", func() {
 				So(subTopicsIDQuery, ShouldNotBeEmpty)
@@ -296,11 +295,11 @@ func TestGetSubtopicsIDsPublic(t *testing.T) {
 		}
 
 		Convey("When getSubtopicsIDsPublic is called", func() {
-			subTopicsIDQuery := mockGetSubtopicsIDsPublic(ctx, subtopicsIDChan, failedGetSubtopicClient, testCensusTopicID)
+			subTopicsIDQuery := mockGetSubtopicsIDsPublic(ctx, subtopicsIDChan, failedGetSubtopicClient, cache.CensusTopicID)
 
 			Convey("Then no subtopic ids should be sent to subtopicsIDChan channel", func() {
 				// the query only contains the root topic id and no subtopic ids
-				So(subTopicsIDQuery, ShouldEqual, testCensusTopicID)
+				So(subTopicsIDQuery, ShouldEqual, cache.CensusTopicID)
 			})
 		})
 	})
@@ -317,11 +316,11 @@ func TestGetSubtopicsIDsPublic(t *testing.T) {
 		}
 
 		Convey("When getSubtopicsIDsPublic is called", func() {
-			subTopicsIDQuery := mockGetSubtopicsIDsPublic(ctx, subtopicsIDChan, subtopicItemsNilClient, testCensusTopicID)
+			subTopicsIDQuery := mockGetSubtopicsIDsPublic(ctx, subtopicsIDChan, subtopicItemsNilClient, cache.CensusTopicID)
 
 			Convey("Then no subtopic ids should be sent to subtopicsIDChan channel", func() {
 				// the query only contains the root topic id and no subtopic ids
-				So(subTopicsIDQuery, ShouldEqual, testCensusTopicID)
+				So(subTopicsIDQuery, ShouldEqual, cache.CensusTopicID)
 			})
 		})
 	})

--- a/cache/topic.go
+++ b/cache/topic.go
@@ -52,20 +52,20 @@ func (dc *TopicCache) GetData(ctx context.Context, key string) (*Topic, error) {
 	if !ok {
 		err := fmt.Errorf("cached topic data with key %s not found", key)
 		log.Error(ctx, "failed to get cached topic data", err)
-		return nil, err
+		return getEmptyTopic(), err
 	}
 
 	topicCacheData, ok := topicCacheInterface.(*Topic)
 	if !ok {
 		err := errors.New("topicCacheInterface is not type *Topic")
 		log.Error(ctx, "failed type assertion on topicCacheInterface", err)
-		return nil, err
+		return getEmptyTopic(), err
 	}
 
 	if topicCacheData == nil {
 		err := errors.New("topicCacheData is nil")
 		log.Error(ctx, "cached topic data is nil", err)
-		return nil, err
+		return getEmptyTopic(), err
 	}
 
 	return topicCacheData, nil
@@ -87,7 +87,7 @@ func (dc *TopicCache) GetCensusData(ctx context.Context) (*Topic, error) {
 			"key": CensusTopicID,
 		}
 		log.Error(ctx, "failed to get cached census topic data", err, logData)
-		return nil, err
+		return GetEmptyCensusTopic(), err
 	}
 
 	return censusTopicCache, nil
@@ -97,6 +97,13 @@ func (dc *TopicCache) GetCensusData(ctx context.Context) (*Topic, error) {
 func GetEmptyCensusTopic() *Topic {
 	return &Topic{
 		ID:   CensusTopicID,
+		List: NewSubTopicsMap(),
+	}
+}
+
+// GetEmptyTopic returns an empty topic cache in the event when updating the cache of the topic fails
+func getEmptyTopic() *Topic {
+	return &Topic{
 		List: NewSubTopicsMap(),
 	}
 }

--- a/cache/topic.go
+++ b/cache/topic.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	// CensusTopicTitle is the title of the Census topic stored in mongodb which is accessible by using dp-topic-api
-	CensusTopicTitle = "Census"
+	// CensusTopicTitle is the id of the Census topic stored in mongodb which is accessible by using dp-topic-api
+	CensusTopicID = "4445"
 )
 
 // TopicCache is a wrapper to dpcache.Cache which has additional fields and methods specifically for caching topics
@@ -81,10 +81,10 @@ func (dc *TopicCache) AddUpdateFunc(title string, updateFunc func() *Topic) {
 }
 
 func (dc *TopicCache) GetCensusData(ctx context.Context) (*Topic, error) {
-	censusTopicCache, err := dc.GetData(ctx, CensusTopicTitle)
+	censusTopicCache, err := dc.GetData(ctx, CensusTopicID)
 	if err != nil {
 		logData := log.Data{
-			"key": CensusTopicTitle,
+			"key": CensusTopicID,
 		}
 		log.Error(ctx, "failed to get cached census topic data", err, logData)
 		return nil, err
@@ -96,7 +96,7 @@ func (dc *TopicCache) GetCensusData(ctx context.Context) (*Topic, error) {
 // GetEmptyCensusTopic returns an empty census topic cache in the event when updating the cache of the census topic fails
 func GetEmptyCensusTopic() *Topic {
 	return &Topic{
-		LocaliseKeyName: CensusTopicTitle,
-		List:            NewSubTopicsMap(),
+		ID:   CensusTopicID,
+		List: NewSubTopicsMap(),
 	}
 }

--- a/cache/topic_test.go
+++ b/cache/topic_test.go
@@ -69,7 +69,7 @@ func TestGetData(t *testing.T) {
 	}
 
 	Convey("Given a valid topic id which exists", t, func() {
-		id := CensusTopicTitle
+		id := CensusTopicID
 
 		Convey("When GetData is called", func() {
 			testCacheData, err := mockCacheList.CensusTopic.GetData(ctx, id)
@@ -217,8 +217,8 @@ func TestGetEmptyCensusTopic(t *testing.T) {
 		emptyCensusTopic := GetEmptyCensusTopic()
 
 		Convey("Then an empty census topic should be returned", func() {
-			So(emptyCensusTopic.ID, ShouldEqual, "")
-			So(emptyCensusTopic.LocaliseKeyName, ShouldEqual, CensusTopicTitle)
+			So(emptyCensusTopic.ID, ShouldEqual, CensusTopicID)
+			So(emptyCensusTopic.LocaliseKeyName, ShouldEqual, "")
 			So(emptyCensusTopic.Query, ShouldEqual, "")
 			So(emptyCensusTopic.List, ShouldNotBeNil)
 		})

--- a/cache/topic_test.go
+++ b/cache/topic_test.go
@@ -93,8 +93,8 @@ func TestGetData(t *testing.T) {
 			Convey("Then an error should be returned", func() {
 				So(err, ShouldNotBeNil)
 
-				Convey("And the cache data returned should be nil", func() {
-					So(testCacheData, ShouldBeNil)
+				Convey("And the cache data returned should be empty", func() {
+					So(testCacheData, ShouldResemble, getEmptyTopic())
 				})
 			})
 		})
@@ -113,8 +113,8 @@ func TestGetData(t *testing.T) {
 			Convey("Then an error should be returned", func() {
 				So(err, ShouldNotBeNil)
 
-				Convey("And the cache data returned should be nil", func() {
-					So(testCacheData, ShouldBeNil)
+				Convey("And the cache data returned should be empty", func() {
+					So(testCacheData, ShouldResemble, getEmptyTopic())
 				})
 			})
 		})
@@ -133,8 +133,8 @@ func TestGetData(t *testing.T) {
 			Convey("Then an error should be returned", func() {
 				So(err, ShouldNotBeNil)
 
-				Convey("And the cache data returned should be nil", func() {
-					So(testCacheData, ShouldBeNil)
+				Convey("And the cache data returned should be empty", func() {
+					So(testCacheData, ShouldResemble, getEmptyTopic())
 				})
 			})
 		})
@@ -175,8 +175,8 @@ func TestGetCensusData(t *testing.T) {
 			Convey("Then an error should be returned", func() {
 				So(err, ShouldNotBeNil)
 
-				Convey("And the census cache data returned should be nil", func() {
-					So(censusData, ShouldBeNil)
+				Convey("And the census cache data returned should be empty", func() {
+					So(censusData, ShouldResemble, GetEmptyCensusTopic())
 				})
 			})
 		})

--- a/config/config.go
+++ b/config/config.go
@@ -43,7 +43,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9002/dist/assets"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/824e12c"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/b6824ed"
 	}
 	return cfg, nil
 }

--- a/data/query.go
+++ b/data/query.go
@@ -62,10 +62,6 @@ func GetSearchAPIQuery(validatedQueryParams SearchURLParams) url.Values {
 	// update content_type query (filters) with sub filters
 	updateQueryWithAPIFilters(apiQuery)
 
-	// TODO finish the process for querying topics once the API is up and running, currently apiQuery will not include topics and so does nothing
-	// update topics query with subtopics
-	updateQueryWithAPITopics(apiQuery)
-
 	return apiQuery
 }
 

--- a/data/topic_filter.go
+++ b/data/topic_filter.go
@@ -48,12 +48,10 @@ var defaultTopics = ""
 
 // reviewTopicFilters retrieves subtopic ids from query, checks if they are one of the census subtopics, and updates validatedQueryParams
 func reviewTopicFilters(ctx context.Context, urlQuery url.Values, validatedQueryParams *SearchURLParams, censusTopicCache *cache.Topic) error {
-	// handles if more than one instance of topics query is given in the url
-	topicFiltersQuery := urlQuery["topics"]
-	topicFilterQueryString := strings.Join(topicFiltersQuery, ",")
+	topicFilters := urlQuery.Get("topics")
+	topicIDs := strings.Split(topicFilters, ",")
 
 	validatedTopicFilters := []string{}
-	topicIDs := strings.Split(topicFilterQueryString, ",")
 
 	for i := range topicIDs {
 

--- a/data/topic_filter.go
+++ b/data/topic_filter.go
@@ -61,13 +61,15 @@ func reviewTopicFilters(ctx context.Context, urlQuery url.Values, validatedQuery
 			continue
 		}
 
-		// checks if topic id is a subtopic id of the census topic
-		found := censusTopicCache.List.Get(topicFilterQuery)
-		if !found {
-			err := errs.ErrFilterNotFound
-			logData := log.Data{"subtopic id not found": topicFilterQuery}
-			log.Error(ctx, "failed to find subtopic id in census topic data", err, logData)
-			return err
+		if topicFilterQuery != censusTopicCache.ID {
+			// checks if topic id is a subtopic id of the census topic
+			found := censusTopicCache.List.Get(topicFilterQuery)
+			if !found {
+				err := errs.ErrTopicNotFound
+				logData := log.Data{"subtopic id not found": topicFilterQuery}
+				log.Error(ctx, "failed to find subtopic id in census topic data", err, logData)
+				return err
+			}
 		}
 
 		validatedTopicFilters = append(validatedTopicFilters, topicIDs[i])

--- a/data/topic_filter_test.go
+++ b/data/topic_filter_test.go
@@ -207,7 +207,7 @@ func TestReviewTopicFilters(t *testing.T) {
 
 			Convey("Then return an error", func() {
 				So(err, ShouldNotBeNil)
-				So(err, ShouldResemble, errs.ErrFilterNotFound)
+				So(err, ShouldResemble, errs.ErrTopicNotFound)
 			})
 		})
 	})
@@ -224,7 +224,7 @@ func TestReviewTopicFilters(t *testing.T) {
 
 			Convey("Then return an error", func() {
 				So(err, ShouldNotBeNil)
-				So(err, ShouldResemble, errs.ErrFilterNotFound)
+				So(err, ShouldResemble, errs.ErrTopicNotFound)
 			})
 		})
 	})
@@ -241,7 +241,7 @@ func TestReviewTopicFilters(t *testing.T) {
 
 			Convey("Then return an error", func() {
 				So(err, ShouldNotBeNil)
-				So(err, ShouldResemble, errs.ErrFilterNotFound)
+				So(err, ShouldResemble, errs.ErrTopicNotFound)
 			})
 		})
 	})

--- a/data/topic_filter_test.go
+++ b/data/topic_filter_test.go
@@ -18,7 +18,7 @@ func TestGetTopicCategories(t *testing.T) {
 		mockSearchCliResponse := searchCli.Response{
 			Topics: []searchCli.FilterCount{
 				{
-					Type:  "1234",
+					Type:  cache.CensusTopicID,
 					Count: 1,
 				},
 			},

--- a/data/topic_filter_test.go
+++ b/data/topic_filter_test.go
@@ -205,7 +205,7 @@ func TestReviewTopicFilters(t *testing.T) {
 		Convey("When reviewTopicFilters is called", func() {
 			err := reviewTopicFilters(ctx, urlQuery, validatedQueryParams, mockCensusTopic)
 
-			Convey("Then return no error", func() {
+			Convey("Then return an error", func() {
 				So(err, ShouldNotBeNil)
 				So(err, ShouldResemble, errs.ErrFilterNotFound)
 			})

--- a/data/topic_filter_test.go
+++ b/data/topic_filter_test.go
@@ -169,15 +169,15 @@ func TestReviewTopicFilters(t *testing.T) {
 				So(err, ShouldBeNil)
 			})
 
-			Convey("And update validatedQueryParams for topics", func() {
-				So(validatedQueryParams.TopicFilter, ShouldEqual, "1234,5678")
+			Convey("And update validatedQueryParams for the first given topic", func() {
+				So(validatedQueryParams.TopicFilter, ShouldEqual, "1234")
 			})
 		})
 	})
 
 	Convey("Given a mix of empty and valid topics", t, func() {
 		urlQuery := url.Values{
-			"topics": []string{"", "1234"},
+			"topics": []string{"1234", ""},
 		}
 
 		validatedQueryParams := &SearchURLParams{}
@@ -214,7 +214,7 @@ func TestReviewTopicFilters(t *testing.T) {
 
 	Convey("Given a mix of valid and invalid topics", t, func() {
 		urlQuery := url.Values{
-			"topics": []string{"1234", "invalid"},
+			"topics": []string{"1234,invalid"},
 		}
 
 		validatedQueryParams := &SearchURLParams{}
@@ -231,7 +231,7 @@ func TestReviewTopicFilters(t *testing.T) {
 
 	Convey("Given a mix of empty, valid and invalid topics", t, func() {
 		urlQuery := url.Values{
-			"topics": []string{"1234", "invalid", ""},
+			"topics": []string{"1234,invalid,"},
 		}
 
 		validatedQueryParams := &SearchURLParams{}

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -8,6 +8,7 @@ import (
 
 	searchCli "github.com/ONSdigital/dp-api-clients-go/v2/site-search"
 	zebedeeCli "github.com/ONSdigital/dp-api-clients-go/v2/zebedee"
+	"github.com/ONSdigital/dp-frontend-search-controller/apperrors"
 	errs "github.com/ONSdigital/dp-frontend-search-controller/apperrors"
 	"github.com/ONSdigital/dp-frontend-search-controller/cache"
 	"github.com/ONSdigital/dp-frontend-search-controller/config"
@@ -46,7 +47,7 @@ func read(w http.ResponseWriter, req *http.Request, cfg *config.Config, zc Zebed
 	}
 
 	validatedQueryParams, err := data.ReviewQuery(ctx, cfg, urlQuery, censusTopicCache)
-	if err != nil && err != errs.ErrInvalidQueryString {
+	if err != nil && !apperrors.ErrMapForRenderBeforeAPICalls[err] {
 		log.Error(ctx, "unable to review query", err)
 		setStatusCode(w, req, err)
 		return
@@ -59,7 +60,7 @@ func read(w http.ResponseWriter, req *http.Request, cfg *config.Config, zc Zebed
 	var respErr error
 	var departmentResp searchCli.Department
 
-	if err == errs.ErrInvalidQueryString {
+	if apperrors.ErrMapForRenderBeforeAPICalls[err] {
 		// avoid making any API calls
 		basePage := rend.NewBasePageModel()
 		m := mapper.CreateSearchPage(cfg, req, basePage, validatedQueryParams, []data.Category{}, []data.Topic{}, searchResp, departmentResp, lang, homepageResponse, err.Error())

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -8,7 +8,6 @@ import (
 
 	searchCli "github.com/ONSdigital/dp-api-clients-go/v2/site-search"
 	zebedeeCli "github.com/ONSdigital/dp-api-clients-go/v2/zebedee"
-	"github.com/ONSdigital/dp-frontend-search-controller/apperrors"
 	errs "github.com/ONSdigital/dp-frontend-search-controller/apperrors"
 	"github.com/ONSdigital/dp-frontend-search-controller/cache"
 	"github.com/ONSdigital/dp-frontend-search-controller/config"
@@ -47,7 +46,7 @@ func read(w http.ResponseWriter, req *http.Request, cfg *config.Config, zc Zebed
 	}
 
 	validatedQueryParams, err := data.ReviewQuery(ctx, cfg, urlQuery, censusTopicCache)
-	if err != nil && !apperrors.ErrMapForRenderBeforeAPICalls[err] {
+	if err != nil && !errs.ErrMapForRenderBeforeAPICalls[err] {
 		log.Error(ctx, "unable to review query", err)
 		setStatusCode(w, req, err)
 		return
@@ -60,7 +59,7 @@ func read(w http.ResponseWriter, req *http.Request, cfg *config.Config, zc Zebed
 	var respErr error
 	var departmentResp searchCli.Department
 
-	if apperrors.ErrMapForRenderBeforeAPICalls[err] {
+	if errs.ErrMapForRenderBeforeAPICalls[err] {
 		// avoid making any API calls
 		basePage := rend.NewBasePageModel()
 		m := mapper.CreateSearchPage(cfg, req, basePage, validatedQueryParams, []data.Category{}, []data.Topic{}, searchResp, departmentResp, lang, homepageResponse, err.Error())

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -45,7 +45,7 @@ var (
 	mockCensusTopic = &cache.Topic{
 		ID:              "1234",
 		LocaliseKeyName: "Census",
-		Query:           "1234,5678",
+		Query:           "1234",
 	}
 )
 

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ONSdigital/dp-frontend-search-controller/cache"
 	"github.com/ONSdigital/dp-frontend-search-controller/config"
 	"github.com/ONSdigital/dp-frontend-search-controller/data"
 	"github.com/ONSdigital/dp-renderer/model"
@@ -15,7 +14,7 @@ import (
 var (
 	mockTopicCategories = []data.Topic{
 		{
-			LocaliseKeyName: cache.CensusTopicTitle,
+			LocaliseKeyName: "Census",
 			Count:           1,
 			Query:           "1234",
 			ShowInWebUI:     true,
@@ -183,7 +182,7 @@ func TestUnitCreateSearchPage(t *testing.T) {
 				So(sp.Data.TopicFilters, ShouldNotBeEmpty)
 				So(sp.Data.TopicFilters[0], ShouldNotBeEmpty)
 				So(sp.Data.TopicFilters[0].IsChecked, ShouldBeTrue)
-				So(sp.Data.TopicFilters[0].LocaliseKeyName, ShouldEqual, cache.CensusTopicTitle)
+				So(sp.Data.TopicFilters[0].LocaliseKeyName, ShouldEqual, "Census")
 				So(sp.Data.TopicFilters[0].NumberOfResults, ShouldEqual, 1)
 				So(sp.Data.TopicFilters[0].Query, ShouldEqual, "1234")
 
@@ -324,7 +323,7 @@ func TestUnitCreateSearchPageES710(t *testing.T) {
 				So(sp.Data.TopicFilters, ShouldNotBeEmpty)
 				So(sp.Data.TopicFilters[0], ShouldNotBeEmpty)
 				So(sp.Data.TopicFilters[0].IsChecked, ShouldBeTrue)
-				So(sp.Data.TopicFilters[0].LocaliseKeyName, ShouldEqual, cache.CensusTopicTitle)
+				So(sp.Data.TopicFilters[0].LocaliseKeyName, ShouldEqual, "Census")
 				So(sp.Data.TopicFilters[0].NumberOfResults, ShouldEqual, 1)
 				So(sp.Data.TopicFilters[0].Query, ShouldEqual, "1234")
 

--- a/service/service.go
+++ b/service/service.go
@@ -81,9 +81,9 @@ func (svc *Service) Init(ctx context.Context, cfg *config.Config, serviceList *E
 		return err
 	}
 	if cfg.IsPublishing {
-		svc.Cache.CensusTopic.AddUpdateFunc(cache.CensusTopicTitle, cachePrivate.UpdateCensusTopic(ctx, cfg.ServiceAuthToken, clients.Topic))
+		svc.Cache.CensusTopic.AddUpdateFunc(cache.CensusTopicID, cachePrivate.UpdateCensusTopic(ctx, cfg.ServiceAuthToken, clients.Topic))
 	} else {
-		svc.Cache.CensusTopic.AddUpdateFunc(cache.CensusTopicTitle, cachePublic.UpdateCensusTopic(ctx, clients.Topic))
+		svc.Cache.CensusTopic.AddUpdateFunc(cache.CensusTopicID, cachePublic.UpdateCensusTopic(ctx, clients.Topic))
 	}
 
 	// Initialise router


### PR DESCRIPTION
### What
**Describe what you have changed and why.**
- Update dp-design-system hash (https://github.com/ONSdigital/dp-design-system/releases/tag/v1.21.0)
- Update `filter.tmpl` to render and use topic filters in the search page
- Get the first instances of the topics key in the url and its corresponding value
- Set topic ID as key for the cache map for topics filter - the id will not change but the name of the topic can change
- Handle when topic is not found - the search page should still be rendered
- Check topic query with root topic id
- Return empty topic rather than nil to handle caching failures better

### How to review
**Describe the steps required to test the changes.**
- Check if the code changes make sense
- Check if the test passes

### Who can review
**Describe who worked on the changes, so that other people can review.**
- Anyone