### PR TITLE
separate validation of the topic query and updating the topic query with subtopics

### DIFF
--- a/cache/mock.go
+++ b/cache/mock.go
@@ -1,6 +1,9 @@
 package cache
 
-import "context"
+import (
+	"context"
+	"fmt"
+)
 
 // GetMockCensusTopicCacheList returns a mocked list of cache which contains the census topic cache and the census topic cache itself
 // should have census topic data
@@ -24,12 +27,13 @@ func GetMockCensusTopic() *Topic {
 	mockCensusTopic := &Topic{
 		ID:              CensusTopicID,
 		LocaliseKeyName: "Census",
-		Query:           "1234,5678",
+		Query:           fmt.Sprintf("1234,5678,%s", CensusTopicID),
 	}
 
 	mockCensusTopic.List = NewSubTopicsMap()
 	mockCensusTopic.List.AppendSubtopicID("1234")
 	mockCensusTopic.List.AppendSubtopicID("5678")
+	mockCensusTopic.List.AppendSubtopicID(CensusTopicID)
 
 	return mockCensusTopic
 }

--- a/cache/mock_test.go
+++ b/cache/mock_test.go
@@ -38,9 +38,10 @@ func TestGetMockCensusTopic(t *testing.T) {
 			So(mockCensusTopic, ShouldNotBeNil)
 			So(mockCensusTopic.ID, ShouldEqual, CensusTopicID)
 			So(mockCensusTopic.LocaliseKeyName, ShouldEqual, "Census")
-			So(mockCensusTopic.Query, ShouldEqual, "1234,5678")
+			So(mockCensusTopic.Query, ShouldEqual, "1234,5678,4445")
 			So(mockCensusTopic.List.Get("1234"), ShouldBeTrue)
 			So(mockCensusTopic.List.Get("5678"), ShouldBeTrue)
+			So(mockCensusTopic.List.Get("4445"), ShouldBeTrue)
 		})
 	})
 }

--- a/data/query.go
+++ b/data/query.go
@@ -56,11 +56,14 @@ func ReviewQuery(ctx context.Context, cfg *config.Config, urlQuery url.Values, c
 }
 
 // GetSearchAPIQuery gets the query that needs to be passed to the search-api to get search results
-func GetSearchAPIQuery(validatedQueryParams SearchURLParams) url.Values {
+func GetSearchAPIQuery(validatedQueryParams SearchURLParams, censusTopicCache *cache.Topic) url.Values {
 	apiQuery := createSearchAPIQuery(validatedQueryParams)
 
 	// update content_type query (filters) with sub filters
 	updateQueryWithAPIFilters(apiQuery)
+
+	// update topics query with sub topics for dp-search-api
+	updateTopicsQueryForSearchAPI(apiQuery, censusTopicCache)
 
 	return apiQuery
 }

--- a/data/query_test.go
+++ b/data/query_test.go
@@ -111,6 +111,8 @@ func TestUnitReviewQueryFailure(t *testing.T) {
 func TestUnitGetSearchAPIQuerySuccess(t *testing.T) {
 	t.Parallel()
 
+	mockCensusTopic := cache.GetMockCensusTopic()
+
 	Convey("Given validated query parameters", t, func() {
 		validatedQueryParams := SearchURLParams{
 			Query: "housing",
@@ -128,7 +130,7 @@ func TestUnitGetSearchAPIQuerySuccess(t *testing.T) {
 		}
 
 		Convey("When GetSearchAPIQuery is called", func() {
-			apiQuery := GetSearchAPIQuery(validatedQueryParams)
+			apiQuery := GetSearchAPIQuery(validatedQueryParams, mockCensusTopic)
 
 			Convey("Then successfully return apiQuery for dp-search-api", func() {
 				So(apiQuery["q"], ShouldResemble, []string{"housing"})

--- a/data/topic_filter.go
+++ b/data/topic_filter.go
@@ -58,14 +58,6 @@ func reviewTopicFilters(ctx context.Context, urlQuery url.Values, validatedQuery
 			continue
 		}
 
-		// if topic id is root id of the census topic
-		if topicFilterQuery == censusTopicCache.ID {
-			// append topic root id and its subtopic ids
-			validatedTopicFilters = append(validatedTopicFilters, censusTopicCache.Query)
-			continue
-		}
-
-		// else check if topic id is a subtopic id of the census topic
 		found := censusTopicCache.List.Get(topicFilterQuery)
 		if !found {
 			err := errs.ErrTopicNotFound
@@ -80,4 +72,25 @@ func reviewTopicFilters(ctx context.Context, urlQuery url.Values, validatedQuery
 	validatedQueryParams.TopicFilter = strings.Join(validatedTopicFilters, ",")
 
 	return nil
+}
+
+// updateTopicsQueryForSearchAPI updates the topics query with subtopic ids if one of the topic is a root id
+func updateTopicsQueryForSearchAPI(apiQuery url.Values, censusTopicCache *cache.Topic) {
+	topicFilters := apiQuery.Get("topics")
+	topicIDs := strings.Split(topicFilters, ",")
+
+	rootAndSubtopics := []string{}
+
+	for i := range topicIDs {
+		// if topic id is root id of the census topic
+		if topicIDs[i] == censusTopicCache.ID {
+			// append topic root id and its subtopic ids
+			rootAndSubtopics = append(rootAndSubtopics, censusTopicCache.Query)
+			continue
+		}
+
+		rootAndSubtopics = append(rootAndSubtopics, topicIDs[i])
+	}
+
+	apiQuery.Set("topics", strings.Join(rootAndSubtopics, ","))
 }

--- a/data/topic_filter_test.go
+++ b/data/topic_filter_test.go
@@ -246,3 +246,51 @@ func TestReviewTopicFilters(t *testing.T) {
 		})
 	})
 }
+
+func TestUpdateTopicsQueryForSearchAPI(t *testing.T) {
+	t.Parallel()
+
+	mockCensusTopic := cache.GetMockCensusTopic()
+
+	Convey("Given the topics query is a root topic id", t, func() {
+		apiQuery := url.Values{
+			"topics": []string{"4445"},
+		}
+
+		Convey("When updateTopicsQueryForSearchAPI is called", func() {
+			updateTopicsQueryForSearchAPI(apiQuery, mockCensusTopic)
+
+			Convey("Then topics is updated with subtopics in apiQuery", func() {
+				So(apiQuery.Get("topics"), ShouldEqual, mockCensusTopic.Query)
+			})
+		})
+	})
+
+	Convey("Given the topics query is not a root topic id", t, func() {
+		apiQuery := url.Values{
+			"topics": []string{"1234"},
+		}
+
+		Convey("When updateTopicsQueryForSearchAPI is called", func() {
+			updateTopicsQueryForSearchAPI(apiQuery, mockCensusTopic)
+
+			Convey("Then topics should not be updated in apiQuery", func() {
+				So(apiQuery.Get("topics"), ShouldEqual, "1234")
+			})
+		})
+	})
+
+	Convey("Given the topics query is a mix of root topic id and subtopic id", t, func() {
+		apiQuery := url.Values{
+			"topics": []string{"4445,6345"},
+		}
+
+		Convey("When updateTopicsQueryForSearchAPI is called", func() {
+			updateTopicsQueryForSearchAPI(apiQuery, mockCensusTopic)
+
+			Convey("Then topics is updated with subtopics for the root topic id in apiQuery", func() {
+				So(apiQuery.Get("topics"), ShouldEqual, "1234,5678,4445,6345")
+			})
+		})
+	})
+}

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -52,7 +52,7 @@ func read(w http.ResponseWriter, req *http.Request, cfg *config.Config, zc Zebed
 		return
 	}
 
-	apiQuery := data.GetSearchAPIQuery(validatedQueryParams)
+	apiQuery := data.GetSearchAPIQuery(validatedQueryParams, censusTopicCache)
 
 	var homepageResponse zebedeeCli.HomepageContent
 	var searchResp searchCli.Response


### PR DESCRIPTION
### What
**Describe what you have changed and why.**
- Separate validation of the topic query and updating the topic query with subtopics
- `reviewTopicFilters` func should only check if the topic id given by the user is valid
- `updateTopicsQueryForSearchAPI` func should update the query with subtopics to be sent to search-api

### How to review
**Describe the steps required to test the changes.**
- Check if the code changes make sense
- Check if the test passes

### Who can review
**Describe who worked on the changes, so that other people can review.**
- Anyone