### PR TITLE
add check to see if total pages is less than pages we want to display to prevent page numbers outside of range

### DIFF
--- a/data/pagination.go
+++ b/data/pagination.go
@@ -159,7 +159,7 @@ func getStartPage(cfg *config.Config, currentPage int, totalPages int) int {
 
 	startPage := currentPage - pageOffset
 
-	if currentPage <= pageOffset {
+	if (currentPage <= pageOffset) || (totalPages < noOfPagesToDisplay) {
 		startPage = cfg.DefaultPage
 	} else if (currentPage == totalPages-1) || (currentPage == totalPages) {
 		startPage = totalPages - noOfPagesToDisplay + 1


### PR DESCRIPTION
### What

add check to see if total pages is less than pages we want to display to prevent page numbers outside of range

stop:
<img width="356" alt="image" src="https://user-images.githubusercontent.com/12159136/179549758-44d405a8-23a3-479a-b55e-4db2e5442725.png">

fix:
<img width="272" alt="image" src="https://user-images.githubusercontent.com/12159136/179549861-cf2b9da0-a0ac-4f87-9cec-ce4c393a6b5c.png">

### How to review

- point your local search controller at prod api e.g. `make debug API_ROUTER_URL="https://api.beta.ons.gov.uk/v1"`
- visit http://localhost:20000/search?q=LANGUAGE&filter=bulletin&filter=article&page=3
- view difference before and after code fix
- test other pages for no breakages

### Who can review

Anyone
