### PR TITLE
bump library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/ONSdigital/dp-healthcheck v1.3.0
 	github.com/ONSdigital/dp-net v1.4.1
 	github.com/ONSdigital/dp-net/v2 v2.4.0
-	github.com/ONSdigital/dp-renderer v1.45.0
+	github.com/ONSdigital/dp-renderer v1.46.0
 	github.com/ONSdigital/log.go/v2 v2.2.0
 	github.com/cucumber/godog v0.12.5
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,8 @@ github.com/ONSdigital/dp-net/v2 v2.4.0 h1:GYJM8ZFGfWOAjUUMO8rXavowAT700q3Zi/vYjc
 github.com/ONSdigital/dp-net/v2 v2.4.0/go.mod h1:8X7E1wiJxL59qaDFt3ShDfFLfIGs4WMRPx1sZIgAqbU=
 github.com/ONSdigital/dp-renderer v1.45.0 h1:DaDakcgbhvGRsDbQgzFswA0BPzCNTUsFNlzVGipPG7M=
 github.com/ONSdigital/dp-renderer v1.45.0/go.mod h1:q/zlK9Qc7b95w7XPfgS7RPLID++CZgaAn0q51QCqZew=
+github.com/ONSdigital/dp-renderer v1.46.0 h1:D0HrijrmXb5dFBUg1CaFoFJkkThDHMdEWPnWNTNJAL0=
+github.com/ONSdigital/dp-renderer v1.46.0/go.mod h1:q/zlK9Qc7b95w7XPfgS7RPLID++CZgaAn0q51QCqZew=
 github.com/ONSdigital/dp-topic-api v0.13.0 h1:5/MZpoThR/RiSaWTKg9iJsXPAqz0aYgiDgRuA1bAWwU=
 github.com/ONSdigital/dp-topic-api v0.13.0/go.mod h1:MipguYB6NVmJtzcdvmQ2DDpVY31PPPOiSFiWDzV5bWw=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=


### PR DESCRIPTION
### What

Bump to latest `dp-renderer` library with fix for screenreader reading feedback confirmation on search pages. 

### How to review

See that library is bumped to `1.46.0`

### Who can review

Anyone.
