### PR TITLE
call Zebedee despite errors

### DIFF
--- a/assets/templates/search.tmpl
+++ b/assets/templates/search.tmpl
@@ -1,8 +1,9 @@
 {{ $lang := .Language }}
+{{ $length := len .Data.Query }}
 <div class="ons-container search__container">
   <div class="ons-grid">
 
-    {{if .Data.ErrorMessage}}
+    {{if or (eq $length 0) (.Data.ErrorMessage)}}
 
       <div class="ons-grid__col ons-col-12@m">
         <section class="search__summary">

--- a/handlers/clients.go
+++ b/handlers/clients.go
@@ -26,7 +26,6 @@ type RenderClient interface {
 // SearchClient is an interface with methods required for a search client
 type SearchClient interface {
 	GetSearch(ctx context.Context, userAuthToken, serviceAuthToken, collectionID string, query url.Values) (r searchCli.Response, err error)
-	GetDepartments(ctx context.Context, userAuthToken, serviceAuthToken, collectionID string, query url.Values) (d searchCli.Department, err error)
 }
 
 // ZebedeeClient is an interface with methods required for a zebedee client

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -243,7 +243,7 @@ func TestUnitReadFailure(t *testing.T) {
 
 				So(len(mockedRendererClient.BuildPageCalls()), ShouldEqual, 0)
 				So(len(mockedSearchClient.GetSearchCalls()), ShouldEqual, 0)
-				So(len(mockedZebedeeClient.GetHomepageContentCalls()), ShouldEqual, 0)
+				So(len(mockedZebedeeClient.GetHomepageContentCalls()), ShouldEqual, 1)
 			})
 		})
 	})
@@ -288,7 +288,6 @@ func TestUnitReadFailure(t *testing.T) {
 
 				So(len(mockedRendererClient.BuildPageCalls()), ShouldEqual, 0)
 				So(len(mockedSearchClient.GetSearchCalls()), ShouldEqual, 1)
-				So(len(mockedSearchClient.GetDepartmentsCalls()), ShouldEqual, 1)
 				So(len(mockedZebedeeClient.GetHomepageContentCalls()), ShouldEqual, 1)
 			})
 		})
@@ -334,7 +333,6 @@ func TestUnitReadFailure(t *testing.T) {
 
 				So(len(mockedRendererClient.BuildPageCalls()), ShouldEqual, 0)
 				So(len(mockedSearchClient.GetSearchCalls()), ShouldEqual, 1)
-				So(len(mockedSearchClient.GetDepartmentsCalls()), ShouldEqual, 1)
 				So(len(mockedZebedeeClient.GetHomepageContentCalls()), ShouldEqual, 1)
 			})
 		})


### PR DESCRIPTION
### What

Emergency banner not displaying when on hits `/search` endpoint without entering search terms. Call was not being made to Zebedee because of an error with query parameters (must be 3 characters in length).

### How to review

Pull this branch, go to `/search`, see that banner displays. 

### Who can review

Nathan, Justin
