### PR TITLE
update references

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -46,7 +46,7 @@ func Get() (*Config, error) {
 	if newCfg.Debug {
 		newCfg.PatternLibraryAssetsPath = "http://localhost:9002/dist/assets"
 	} else {
-		newCfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/efc4b51"
+		newCfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/297621d"
 	}
 
 	return newCfg, nil

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/ONSdigital/dp-healthcheck v1.3.0
 	github.com/ONSdigital/dp-net v1.4.1
 	github.com/ONSdigital/dp-net/v2 v2.4.0
-	github.com/ONSdigital/dp-renderer v1.46.1
+	github.com/ONSdigital/dp-renderer v1.54.0
 	github.com/ONSdigital/dp-topic-api v0.13.3
 	github.com/ONSdigital/log.go/v2 v2.2.0
 	github.com/cucumber/godog v0.12.5

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,8 @@ github.com/ONSdigital/dp-net/v2 v2.4.0 h1:GYJM8ZFGfWOAjUUMO8rXavowAT700q3Zi/vYjc
 github.com/ONSdigital/dp-net/v2 v2.4.0/go.mod h1:8X7E1wiJxL59qaDFt3ShDfFLfIGs4WMRPx1sZIgAqbU=
 github.com/ONSdigital/dp-renderer v1.46.1 h1:Rhn8ni6PGWCjHVUYD4R6FTJmITyaKXKz+q9FvnH2N5w=
 github.com/ONSdigital/dp-renderer v1.46.1/go.mod h1:q/zlK9Qc7b95w7XPfgS7RPLID++CZgaAn0q51QCqZew=
+github.com/ONSdigital/dp-renderer v1.54.0 h1:Zr0xtFavrmuNAsZ4f+vZZnTXdMUcp/ygwiUnreKfMgw=
+github.com/ONSdigital/dp-renderer v1.54.0/go.mod h1:q/zlK9Qc7b95w7XPfgS7RPLID++CZgaAn0q51QCqZew=
 github.com/ONSdigital/dp-topic-api v0.13.3 h1:m2GhGeNWdRKeEiHV3kOsuUnwQ7pqdLxFQYVJIwsuzSo=
 github.com/ONSdigital/dp-topic-api v0.13.3/go.mod h1:MipguYB6NVmJtzcdvmQ2DDpVY31PPPOiSFiWDzV5bWw=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=


### PR DESCRIPTION
### What

Update references to `dp-design-system` and `dp-renderer`. 

### How to review

See that reference to `dp-design-system` matches this [hash](https://github.com/ONSdigital/dp-design-system/releases/tag/v2.3.0) and the reference to the `dp-renderer` matches this [release](https://github.com/ONSdigital/dp-renderer/releases/tag/v1.54.0).

### Who can review

Anyone
