### PR TITLE
Update search topic filters to include census subtopics

### DIFF
--- a/assets/templates/partials/filter.tmpl
+++ b/assets/templates/partials/filter.tmpl
@@ -26,6 +26,31 @@
                         <label class="ons-checkbox__label" for="topic-group-{{ $index }}" id="topic-group-{{ $index }}-label">
                             {{ localise $topicFilter.LocaliseKeyName $lang 4 }} ({{ $topicFilter.NumberOfResults }})
                         </label>
+                        <span class="ons-checkbox__other" id="group-{{ $index }}-other-wrap">
+                            <fieldset class="ons-fieldset ons-js-other-fieldset">
+                                {{ range $index, $childFilter := $topicFilter.Types }}
+                                    {{ $id := index $childFilter.Query 0 }}
+                                    <div class="ons-checkboxes__items">
+                                        <span class="ons-checkboxes__item ons-checkboxes__item--no-border">
+                                            <span class="ons-checkbox ons-checkbox--no-border child-filter">
+                                                <input id="{{ $id }}"
+                                                    class="ons-checkbox__input ons-js-checkbox"
+                                                    type="checkbox" name="filter"
+                                                    {{ if $childFilter.IsChecked }}checked{{ end }}
+                                                    data-gtm-label="{{ $childFilter.LocaliseKeyName }}"
+                                                    value="{{ $id }}"
+                                                    {{ if eq $childFilter.NumberOfResults 0 }} disabled aria-disabled="true" {{ end }}
+                                                />
+                                                <label class="ons-checkbox__label" for="{{ $id }}"
+                                                    id="{{ $id }}-label">
+                                                    {{ $childFilter.LocaliseKeyName }} ({{ $childFilter.NumberOfResults }})
+                                                </label>
+                                            </span>
+                                        </span>
+                                    </div>
+                                {{ end }}
+                            </fieldset>
+                        </span>
                     </span>
                 </span>
             </div>

--- a/cache/mock.go
+++ b/cache/mock.go
@@ -48,9 +48,9 @@ func GetMockCensusTopic() *Topic {
 	}
 
 	mockCensusTopic.List = NewSubTopicsMap()
-	mockCensusTopic.List.AppendSubtopicID("1234")
-	mockCensusTopic.List.AppendSubtopicID("5678")
-	mockCensusTopic.List.AppendSubtopicID(CensusTopicID)
+	mockCensusTopic.List.AppendSubtopicID("1234", Subtopic{LocaliseKeyName: "International Migration", ReleaseDate: "2022-10-10T08:30:00Z"})
+	mockCensusTopic.List.AppendSubtopicID("5678", Subtopic{LocaliseKeyName: "Age", ReleaseDate: "2022-11-09T09:30:00Z"})
+	mockCensusTopic.List.AppendSubtopicID(CensusTopicID, Subtopic{LocaliseKeyName: "Census", ReleaseDate: "2022-10-10T09:30:00Z"})
 
 	return mockCensusTopic
 }

--- a/cache/mock.go
+++ b/cache/mock.go
@@ -48,9 +48,9 @@ func GetMockCensusTopic() *Topic {
 	}
 
 	mockCensusTopic.List = NewSubTopicsMap()
-	mockCensusTopic.List.AppendSubtopicID("1234", Subtopic{LocaliseKeyName: "International Migration", ReleaseDate: "2022-10-10T08:30:00Z"})
-	mockCensusTopic.List.AppendSubtopicID("5678", Subtopic{LocaliseKeyName: "Age", ReleaseDate: "2022-11-09T09:30:00Z"})
-	mockCensusTopic.List.AppendSubtopicID(CensusTopicID, Subtopic{LocaliseKeyName: "Census", ReleaseDate: "2022-10-10T09:30:00Z"})
+	mockCensusTopic.List.AppendSubtopicID("1234", Subtopic{ID: "1234", LocaliseKeyName: "International Migration", ReleaseDate: "2022-10-10T08:30:00Z"})
+	mockCensusTopic.List.AppendSubtopicID("5678", Subtopic{ID: "5678", LocaliseKeyName: "Age", ReleaseDate: "2022-11-09T09:30:00Z"})
+	mockCensusTopic.List.AppendSubtopicID(CensusTopicID, Subtopic{ID: CensusTopicID, LocaliseKeyName: "Census", ReleaseDate: "2022-10-10T09:30:00Z"})
 
 	return mockCensusTopic
 }

--- a/cache/mock_test.go
+++ b/cache/mock_test.go
@@ -43,9 +43,9 @@ func TestGetMockCensusTopic(t *testing.T) {
 			So(mockCensusTopic.ID, ShouldEqual, CensusTopicID)
 			So(mockCensusTopic.LocaliseKeyName, ShouldEqual, "Census")
 			So(mockCensusTopic.Query, ShouldEqual, fmt.Sprintf("1234,5678,%s", CensusTopicID))
-			So(mockCensusTopic.List.Get("1234"), ShouldResemble, Subtopic{LocaliseKeyName: "International Migration", ReleaseDate: "2022-10-10T08:30:00Z"})
-			So(mockCensusTopic.List.Get("5678"), ShouldResemble, Subtopic{LocaliseKeyName: "Age", ReleaseDate: "2022-11-09T09:30:00Z"})
-			So(mockCensusTopic.List.Get(CensusTopicID), ShouldResemble, Subtopic{LocaliseKeyName: "Census", ReleaseDate: "2022-10-10T09:30:00Z"})
+			So(mockCensusTopic.List.Get("1234"), ShouldResemble, Subtopic{ID: "1234", LocaliseKeyName: "International Migration", ReleaseDate: "2022-10-10T08:30:00Z"})
+			So(mockCensusTopic.List.Get("5678"), ShouldResemble, Subtopic{ID: "5678", LocaliseKeyName: "Age", ReleaseDate: "2022-11-09T09:30:00Z"})
+			So(mockCensusTopic.List.Get(CensusTopicID), ShouldResemble, Subtopic{ID: CensusTopicID, LocaliseKeyName: "Census", ReleaseDate: "2022-10-10T09:30:00Z"})
 		})
 	})
 }

--- a/cache/mock_test.go
+++ b/cache/mock_test.go
@@ -43,9 +43,9 @@ func TestGetMockCensusTopic(t *testing.T) {
 			So(mockCensusTopic.ID, ShouldEqual, CensusTopicID)
 			So(mockCensusTopic.LocaliseKeyName, ShouldEqual, "Census")
 			So(mockCensusTopic.Query, ShouldEqual, fmt.Sprintf("1234,5678,%s", CensusTopicID))
-			So(mockCensusTopic.List.Get("1234"), ShouldBeTrue)
-			So(mockCensusTopic.List.Get("5678"), ShouldBeTrue)
-			So(mockCensusTopic.List.Get(CensusTopicID), ShouldBeTrue)
+			So(mockCensusTopic.List.Get("1234"), ShouldResemble, Subtopic{LocaliseKeyName: "International Migration", ReleaseDate: "2022-10-10T08:30:00Z"})
+			So(mockCensusTopic.List.Get("5678"), ShouldResemble, Subtopic{LocaliseKeyName: "Age", ReleaseDate: "2022-11-09T09:30:00Z"})
+			So(mockCensusTopic.List.Get(CensusTopicID), ShouldResemble, Subtopic{LocaliseKeyName: "Census", ReleaseDate: "2022-10-10T09:30:00Z"})
 		})
 	})
 }

--- a/cache/private/census_topic.go
+++ b/cache/private/census_topic.go
@@ -67,6 +67,7 @@ func getRootTopicCachePrivate(ctx context.Context, serviceAuthToken string, subt
 	}
 
 	subtopic := cache.Subtopic{
+		ID:              rootTopic.ID,
 		LocaliseKeyName: rootTopic.Title,
 		ReleaseDate:     rootTopic.ReleaseDate,
 	}

--- a/cache/private/census_topic.go
+++ b/cache/private/census_topic.go
@@ -90,11 +90,12 @@ func getRootTopicCachePrivate(ctx context.Context, serviceAuthToken string, subt
 
 		for s := range subtopicsChan {
 			subtopic := cache.Subtopic{
+				ID:              s.ID,
 				LocaliseKeyName: s.Next.Title,
 				ReleaseDate:     s.Next.ReleaseDate,
 			}
 
-			subtopicsIDMap.AppendSubtopicID(s.Next.ID, subtopic)
+			subtopicsIDMap.AppendSubtopicID(s.ID, subtopic)
 		}
 	}()
 

--- a/cache/private/census_topic.go
+++ b/cache/private/census_topic.go
@@ -43,9 +43,9 @@ func UpdateCensusTopic(ctx context.Context, serviceAuthToken string, topicClient
 		// go through each root topic, find census topic and gets its data for caching which includes subtopic ids
 		for i := range rootTopicItems {
 			if rootTopicItems[i].Current.ID == cache.CensusTopicID {
-				subtopicsIDChan := make(chan string)
+				subtopicsChan := make(chan models.TopicResponse)
 
-				censusTopicCache = getRootTopicCachePrivate(ctx, serviceAuthToken, subtopicsIDChan, topicClient, *rootTopicItems[i].Current)
+				censusTopicCache = getRootTopicCachePrivate(ctx, serviceAuthToken, subtopicsChan, topicClient, *rootTopicItems[i].Current)
 				break
 			}
 		}
@@ -60,14 +60,19 @@ func UpdateCensusTopic(ctx context.Context, serviceAuthToken string, topicClient
 	}
 }
 
-func getRootTopicCachePrivate(ctx context.Context, serviceAuthToken string, subtopicsIDChan chan string, topicClient topicCli.Clienter, rootTopic models.Topic) *cache.Topic {
+func getRootTopicCachePrivate(ctx context.Context, serviceAuthToken string, subtopicsChan chan models.TopicResponse, topicClient topicCli.Clienter, rootTopic models.Topic) *cache.Topic {
 	rootTopicCache := &cache.Topic{
 		ID:              rootTopic.ID,
 		LocaliseKeyName: rootTopic.Title,
 	}
 
+	subtopic := cache.Subtopic{
+		LocaliseKeyName: rootTopic.Title,
+		ReleaseDate:     rootTopic.ReleaseDate,
+	}
+
 	subtopicsIDMap := cache.NewSubTopicsMap()
-	subtopicsIDMap.AppendSubtopicID(rootTopic.ID)
+	subtopicsIDMap.AppendSubtopicID(rootTopic.ID, subtopic)
 
 	var wg sync.WaitGroup
 	wg.Add(2)
@@ -75,15 +80,21 @@ func getRootTopicCachePrivate(ctx context.Context, serviceAuthToken string, subt
 	// get subtopics ids
 	go func() {
 		defer wg.Done()
-		getSubtopicsIDsPrivate(ctx, serviceAuthToken, subtopicsIDChan, topicClient, rootTopic.ID)
-		close(subtopicsIDChan)
+		getSubtopicsIDsPrivate(ctx, serviceAuthToken, subtopicsChan, topicClient, rootTopic.ID)
+		close(subtopicsChan)
 	}()
 
 	// extract subtopic id from channel to update rootTopicCache
 	go func() {
 		defer wg.Done()
-		for subtopicID := range subtopicsIDChan {
-			subtopicsIDMap.AppendSubtopicID(subtopicID)
+
+		for s := range subtopicsChan {
+			subtopic := cache.Subtopic{
+				LocaliseKeyName: s.Next.Title,
+				ReleaseDate:     s.Next.ReleaseDate,
+			}
+
+			subtopicsIDMap.AppendSubtopicID(s.Next.ID, subtopic)
 		}
 	}()
 
@@ -95,7 +106,7 @@ func getRootTopicCachePrivate(ctx context.Context, serviceAuthToken string, subt
 	return rootTopicCache
 }
 
-func getSubtopicsIDsPrivate(ctx context.Context, serviceAuthToken string, subtopicsIDChan chan string, topicClient topicCli.Clienter, topLevelTopicID string) {
+func getSubtopicsIDsPrivate(ctx context.Context, serviceAuthToken string, subtopicsChan chan models.TopicResponse, topicClient topicCli.Clienter, topLevelTopicID string) {
 	topicCliReqHeaders := topicCli.Headers{ServiceAuthToken: serviceAuthToken}
 
 	// get subtopics from dp-topic-api
@@ -128,11 +139,11 @@ func getSubtopicsIDsPrivate(ctx context.Context, serviceAuthToken string, subtop
 		wg.Add(1)
 
 		// send subtopic id to channel
-		subtopicsIDChan <- subTopicItems[i].ID
+		subtopicsChan <- subTopicItems[i]
 
 		go func(index int) {
 			defer wg.Done()
-			getSubtopicsIDsPrivate(ctx, serviceAuthToken, subtopicsIDChan, topicClient, subTopicItems[index].ID)
+			getSubtopicsIDsPrivate(ctx, serviceAuthToken, subtopicsChan, topicClient, subTopicItems[index].ID)
 		}(i)
 	}
 	wg.Wait()

--- a/cache/private/census_topic_test.go
+++ b/cache/private/census_topic_test.go
@@ -119,7 +119,7 @@ var (
 	}
 )
 
-func mockGetSubtopicsIDsPrivate(ctx context.Context, subtopicsIDChan chan string, topicClient sdk.Clienter, topLevelTopicID string) string {
+func mockGetSubtopicsIDsPrivate(ctx context.Context, subtopicsChan chan models.TopicResponse, topicClient sdk.Clienter, topLevelTopicID string) string {
 	var rootTopic models.Topic
 
 	switch topLevelTopicID {
@@ -129,7 +129,7 @@ func mockGetSubtopicsIDsPrivate(ctx context.Context, subtopicsIDChan chan string
 		rootTopic = testCensusRootTopic
 	}
 
-	testTopicCache := getRootTopicCachePrivate(ctx, "", subtopicsIDChan, topicClient, rootTopic)
+	testTopicCache := getRootTopicCachePrivate(ctx, "", subtopicsChan, topicClient, rootTopic)
 
 	return testTopicCache.Query
 }
@@ -241,7 +241,7 @@ func TestGetRootTopicCachePrivate(t *testing.T) {
 
 	ctx := context.Background()
 
-	subtopicsIDChan := make(chan string)
+	subtopicsChan := make(chan models.TopicResponse)
 
 	mockedTopicClient := &mockTopic.ClienterMock{
 		GetSubtopicsPrivateFunc: func(ctx context.Context, reqHeaders sdk.Headers, id string) (*models.PrivateSubtopics, topicCliErr.Error) {
@@ -260,7 +260,7 @@ func TestGetRootTopicCachePrivate(t *testing.T) {
 
 	Convey("Given topic has subtopics", t, func() {
 		Convey("When getRootTopicCachePrivate is called", func() {
-			respCensusTopicCache := getRootTopicCachePrivate(ctx, "", subtopicsIDChan, mockedTopicClient, testCensusRootTopic)
+			respCensusTopicCache := getRootTopicCachePrivate(ctx, "", subtopicsChan, mockedTopicClient, testCensusRootTopic)
 
 			Convey("Then the census topic cache is returned", func() {
 				So(respCensusTopicCache, ShouldNotBeNil)
@@ -301,10 +301,10 @@ func TestGetSubtopicsIDsPrivate(t *testing.T) {
 	}
 
 	Convey("Given topic has subtopics", t, func() {
-		subtopicsIDChan := make(chan string)
+		subtopicsChan := make(chan models.TopicResponse)
 
 		Convey("When getSubtopicsIDsPrivate is called", func() {
-			subTopicsIDQuery := mockGetSubtopicsIDsPrivate(ctx, subtopicsIDChan, mockedTopicClient, cache.CensusTopicID)
+			subTopicsIDQuery := mockGetSubtopicsIDsPrivate(ctx, subtopicsChan, mockedTopicClient, cache.CensusTopicID)
 
 			Convey("Then subtopic ids should be sent to subtopicsIDChan channel", func() {
 				So(subTopicsIDQuery, ShouldNotBeEmpty)
@@ -316,10 +316,10 @@ func TestGetSubtopicsIDsPrivate(t *testing.T) {
 	})
 
 	Convey("Given topic has no subtopics", t, func() {
-		subtopicsIDChan := make(chan string)
+		subtopicsChan := make(chan models.TopicResponse)
 
 		Convey("When getSubtopicsIDsPrivate is called", func() {
-			subTopicsIDQuery := mockGetSubtopicsIDsPrivate(ctx, subtopicsIDChan, mockedTopicClient, testCensusSubTopicID2)
+			subTopicsIDQuery := mockGetSubtopicsIDsPrivate(ctx, subtopicsChan, mockedTopicClient, testCensusSubTopicID2)
 
 			Convey("Then no subtopic ids should be sent to subtopicsIDChan channel", func() {
 				// the query only contains the root topic id and no subtopic ids
@@ -329,7 +329,7 @@ func TestGetSubtopicsIDsPrivate(t *testing.T) {
 	})
 
 	Convey("Given an error in getting sub topics from topic-api", t, func() {
-		subtopicsIDChan := make(chan string)
+		subtopicsChan := make(chan models.TopicResponse)
 
 		failedGetSubtopicClient := &mockTopic.ClienterMock{
 			GetSubtopicsPrivateFunc: func(ctx context.Context, reqHeaders sdk.Headers, id string) (*models.PrivateSubtopics, topicCliErr.Error) {
@@ -340,7 +340,7 @@ func TestGetSubtopicsIDsPrivate(t *testing.T) {
 		}
 
 		Convey("When getSubtopicsIDsPrivate is called", func() {
-			subTopicsIDQuery := mockGetSubtopicsIDsPrivate(ctx, subtopicsIDChan, failedGetSubtopicClient, cache.CensusTopicID)
+			subTopicsIDQuery := mockGetSubtopicsIDsPrivate(ctx, subtopicsChan, failedGetSubtopicClient, cache.CensusTopicID)
 
 			Convey("Then no subtopic ids should be sent to subtopicsIDChan channel", func() {
 				// the query only contains the root topic id and no subtopic ids
@@ -350,7 +350,7 @@ func TestGetSubtopicsIDsPrivate(t *testing.T) {
 	})
 
 	Convey("Given sub topics private items is nil", t, func() {
-		subtopicsIDChan := make(chan string)
+		subtopicsChan := make(chan models.TopicResponse)
 
 		subtopicItemsNilClient := &mockTopic.ClienterMock{
 			GetSubtopicsPrivateFunc: func(ctx context.Context, reqHeaders sdk.Headers, id string) (*models.PrivateSubtopics, topicCliErr.Error) {
@@ -361,7 +361,7 @@ func TestGetSubtopicsIDsPrivate(t *testing.T) {
 		}
 
 		Convey("When getSubtopicsIDsPrivate is called", func() {
-			subTopicsIDQuery := mockGetSubtopicsIDsPrivate(ctx, subtopicsIDChan, subtopicItemsNilClient, cache.CensusTopicID)
+			subTopicsIDQuery := mockGetSubtopicsIDsPrivate(ctx, subtopicsChan, subtopicItemsNilClient, cache.CensusTopicID)
 
 			Convey("Then no subtopic ids should be sent to subtopicsIDChan channel", func() {
 				// the query only contains the root topic id and no subtopic ids

--- a/cache/public/census_topic.go
+++ b/cache/public/census_topic.go
@@ -65,6 +65,7 @@ func getRootTopicCachePublic(ctx context.Context, subtopicsChan chan models.Topi
 	}
 
 	subtopic := cache.Subtopic{
+		ID:              rootTopic.ID,
 		LocaliseKeyName: rootTopic.Title,
 		ReleaseDate:     rootTopic.ReleaseDate,
 	}

--- a/cache/public/census_topic.go
+++ b/cache/public/census_topic.go
@@ -87,6 +87,7 @@ func getRootTopicCachePublic(ctx context.Context, subtopicsChan chan models.Topi
 		defer wg.Done()
 		for s := range subtopicsChan {
 			subtopic := cache.Subtopic{
+				ID:              s.ID,
 				LocaliseKeyName: s.Title,
 				ReleaseDate:     s.ReleaseDate,
 			}

--- a/cache/public/census_topic.go
+++ b/cache/public/census_topic.go
@@ -41,9 +41,9 @@ func UpdateCensusTopic(ctx context.Context, topicClient topicCli.Clienter) func(
 		// go through each root topic, find census topic and gets its data for caching which includes subtopic ids
 		for i := range rootTopicItems {
 			if rootTopicItems[i].ID == cache.CensusTopicID {
-				subtopicsIDChan := make(chan string)
+				subtopicsChan := make(chan models.Topic)
 
-				censusTopicCache = getRootTopicCachePublic(ctx, subtopicsIDChan, topicClient, rootTopicItems[i])
+				censusTopicCache = getRootTopicCachePublic(ctx, subtopicsChan, topicClient, rootTopicItems[i])
 				break
 			}
 		}
@@ -58,14 +58,19 @@ func UpdateCensusTopic(ctx context.Context, topicClient topicCli.Clienter) func(
 	}
 }
 
-func getRootTopicCachePublic(ctx context.Context, subtopicsIDChan chan string, topicClient topicCli.Clienter, rootTopic models.Topic) *cache.Topic {
+func getRootTopicCachePublic(ctx context.Context, subtopicsChan chan models.Topic, topicClient topicCli.Clienter, rootTopic models.Topic) *cache.Topic {
 	rootTopicCache := &cache.Topic{
 		ID:              rootTopic.ID,
 		LocaliseKeyName: rootTopic.Title,
 	}
 
+	subtopic := cache.Subtopic{
+		LocaliseKeyName: rootTopic.Title,
+		ReleaseDate:     rootTopic.ReleaseDate,
+	}
+
 	subtopicsIDMap := cache.NewSubTopicsMap()
-	subtopicsIDMap.AppendSubtopicID(rootTopic.ID)
+	subtopicsIDMap.AppendSubtopicID(rootTopic.ID, subtopic)
 
 	var wg sync.WaitGroup
 	wg.Add(2)
@@ -73,15 +78,20 @@ func getRootTopicCachePublic(ctx context.Context, subtopicsIDChan chan string, t
 	// get subtopics ids
 	go func() {
 		defer wg.Done()
-		getSubtopicsIDsPublic(ctx, subtopicsIDChan, topicClient, rootTopic.ID)
-		close(subtopicsIDChan)
+		getSubtopicsPublic(ctx, subtopicsChan, topicClient, rootTopic.ID)
+		close(subtopicsChan)
 	}()
 
 	// extract subtopic id from channel to update rootTopicCache
 	go func() {
 		defer wg.Done()
-		for subtopicID := range subtopicsIDChan {
-			subtopicsIDMap.AppendSubtopicID(subtopicID)
+		for s := range subtopicsChan {
+			subtopic := cache.Subtopic{
+				LocaliseKeyName: s.Title,
+				ReleaseDate:     s.ReleaseDate,
+			}
+
+			subtopicsIDMap.AppendSubtopicID(s.ID, subtopic)
 		}
 	}()
 
@@ -93,7 +103,7 @@ func getRootTopicCachePublic(ctx context.Context, subtopicsIDChan chan string, t
 	return rootTopicCache
 }
 
-func getSubtopicsIDsPublic(ctx context.Context, subtopicsIDChan chan string, topicClient topicCli.Clienter, topLevelTopicID string) {
+func getSubtopicsPublic(ctx context.Context, subtopicsChan chan models.Topic, topicClient topicCli.Clienter, topLevelTopicID string) {
 	// get subtopics from dp-topic-api
 	subTopics, err := topicClient.GetSubtopicsPublic(ctx, topicCli.Headers{}, topLevelTopicID)
 	if err != nil {
@@ -126,11 +136,11 @@ func getSubtopicsIDsPublic(ctx context.Context, subtopicsIDChan chan string, top
 		wg.Add(1)
 
 		// send subtopic id to channel
-		subtopicsIDChan <- subTopicItems[i].ID
+		subtopicsChan <- subTopicItems[i]
 
 		go func(index int) {
 			defer wg.Done()
-			getSubtopicsIDsPublic(ctx, subtopicsIDChan, topicClient, subTopicItems[index].ID)
+			getSubtopicsPublic(ctx, subtopicsChan, topicClient, subTopicItems[index].ID)
 		}(i)
 	}
 	wg.Wait()

--- a/cache/public/census_topic_test.go
+++ b/cache/public/census_topic_test.go
@@ -87,7 +87,7 @@ var (
 	}
 )
 
-func mockGetSubtopicsIDsPublic(ctx context.Context, subtopicsIDChan chan string, topicClient sdk.Clienter, topLevelTopicID string) string {
+func mockGetSubtopicsIDsPublic(ctx context.Context, subtopicsChan chan models.Topic, topicClient sdk.Clienter, topLevelTopicID string) string {
 	var rootTopic models.Topic
 
 	switch topLevelTopicID {
@@ -97,7 +97,7 @@ func mockGetSubtopicsIDsPublic(ctx context.Context, subtopicsIDChan chan string,
 		rootTopic = testCensusRootTopic
 	}
 
-	testTopicCache := getRootTopicCachePublic(ctx, subtopicsIDChan, topicClient, rootTopic)
+	testTopicCache := getRootTopicCachePublic(ctx, subtopicsChan, topicClient, rootTopic)
 
 	return testTopicCache.Query
 }
@@ -209,7 +209,7 @@ func TestGetRootTopicCachePublic(t *testing.T) {
 
 	ctx := context.Background()
 
-	subtopicsIDChan := make(chan string)
+	subtopicsChan := make(chan models.Topic)
 
 	mockedTopicClient := &mockTopicCli.ClienterMock{
 		GetSubtopicsPublicFunc: func(ctx context.Context, reqHeaders sdk.Headers, id string) (*models.PublicSubtopics, topicCliErr.Error) {
@@ -228,7 +228,7 @@ func TestGetRootTopicCachePublic(t *testing.T) {
 
 	Convey("Given topic has subtopics", t, func() {
 		Convey("When getRootTopicCache is called", func() {
-			respCensusTopicCache := getRootTopicCachePublic(ctx, subtopicsIDChan, mockedTopicClient, testCensusRootTopic)
+			respCensusTopicCache := getRootTopicCachePublic(ctx, subtopicsChan, mockedTopicClient, testCensusRootTopic)
 
 			Convey("Then the census topic cache is returned", func() {
 				So(respCensusTopicCache, ShouldNotBeNil)
@@ -269,10 +269,10 @@ func TestGetSubtopicsIDsPublic(t *testing.T) {
 	}
 
 	Convey("Given topic has subtopics", t, func() {
-		subtopicsIDChan := make(chan string)
+		subtopicsChan := make(chan models.Topic)
 
 		Convey("When getSubtopicsIDsPublic is called", func() {
-			subTopicsIDQuery := mockGetSubtopicsIDsPublic(ctx, subtopicsIDChan, mockedTopicClient, cache.CensusTopicID)
+			subTopicsIDQuery := mockGetSubtopicsIDsPublic(ctx, subtopicsChan, mockedTopicClient, cache.CensusTopicID)
 
 			Convey("Then subtopic ids should be sent to subtopicsIDChan channel", func() {
 				So(subTopicsIDQuery, ShouldNotBeEmpty)
@@ -284,10 +284,10 @@ func TestGetSubtopicsIDsPublic(t *testing.T) {
 	})
 
 	Convey("Given topic has no subtopics", t, func() {
-		subtopicsIDChan := make(chan string)
+		subtopicsChan := make(chan models.Topic)
 
 		Convey("When getSubtopicsIDsPublic is called", func() {
-			subTopicsIDQuery := mockGetSubtopicsIDsPublic(ctx, subtopicsIDChan, mockedTopicClient, testCensusSubTopicID2)
+			subTopicsIDQuery := mockGetSubtopicsIDsPublic(ctx, subtopicsChan, mockedTopicClient, testCensusSubTopicID2)
 
 			Convey("Then no subtopic ids should be sent to subtopicsIDChan channel", func() {
 				// the query only contains the root topic id and no subtopic ids
@@ -297,7 +297,7 @@ func TestGetSubtopicsIDsPublic(t *testing.T) {
 	})
 
 	Convey("Given an error in getting sub topics from topic-api", t, func() {
-		subtopicsIDChan := make(chan string)
+		subtopicsChan := make(chan models.Topic)
 
 		failedGetSubtopicClient := &mockTopicCli.ClienterMock{
 			GetSubtopicsPublicFunc: func(ctx context.Context, reqHeaders sdk.Headers, id string) (*models.PublicSubtopics, topicCliErr.Error) {
@@ -308,7 +308,7 @@ func TestGetSubtopicsIDsPublic(t *testing.T) {
 		}
 
 		Convey("When getSubtopicsIDsPublic is called", func() {
-			subTopicsIDQuery := mockGetSubtopicsIDsPublic(ctx, subtopicsIDChan, failedGetSubtopicClient, cache.CensusTopicID)
+			subTopicsIDQuery := mockGetSubtopicsIDsPublic(ctx, subtopicsChan, failedGetSubtopicClient, cache.CensusTopicID)
 
 			Convey("Then no subtopic ids should be sent to subtopicsIDChan channel", func() {
 				// the query only contains the root topic id and no subtopic ids
@@ -318,7 +318,7 @@ func TestGetSubtopicsIDsPublic(t *testing.T) {
 	})
 
 	Convey("Given sub topics public items is nil", t, func() {
-		subtopicsIDChan := make(chan string)
+		subtopicsChan := make(chan models.Topic)
 
 		subtopicItemsNilClient := &mockTopicCli.ClienterMock{
 			GetSubtopicsPublicFunc: func(ctx context.Context, reqHeaders sdk.Headers, id string) (*models.PublicSubtopics, topicCliErr.Error) {
@@ -329,7 +329,7 @@ func TestGetSubtopicsIDsPublic(t *testing.T) {
 		}
 
 		Convey("When getSubtopicsIDsPublic is called", func() {
-			subTopicsIDQuery := mockGetSubtopicsIDsPublic(ctx, subtopicsIDChan, subtopicItemsNilClient, cache.CensusTopicID)
+			subTopicsIDQuery := mockGetSubtopicsIDsPublic(ctx, subtopicsChan, subtopicItemsNilClient, cache.CensusTopicID)
 
 			Convey("Then no subtopic ids should be sent to subtopicsIDChan channel", func() {
 				// the query only contains the root topic id and no subtopic ids

--- a/cache/subtopic.go
+++ b/cache/subtopic.go
@@ -41,8 +41,8 @@ func (t *Subtopics) GetSubtopics(key string) (subtopics []Subtopic) {
 		return
 	}
 
-	t.mutex.RLock()
-	defer t.mutex.RUnlock()
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
 
 	for _, subtopic := range t.subtopicsMap {
 		subtopics = append(subtopics, subtopic)

--- a/cache/subtopic.go
+++ b/cache/subtopic.go
@@ -10,23 +10,40 @@ import (
 // and to check if the subtopic id given by a user exists
 type SubtopicsIDs struct {
 	mutex        *sync.RWMutex
-	subtopicsMap map[string]bool
+	subtopicsMap map[string]Subtopic
+}
+
+type Subtopic struct {
+	LocaliseKeyName string
+	ReleaseDate     string
 }
 
 // GetNewSubTopicsMap creates a new subtopics id map to store subtopic ids with addition to mutex locking
 func NewSubTopicsMap() *SubtopicsIDs {
 	return &SubtopicsIDs{
 		mutex:        &sync.RWMutex{},
-		subtopicsMap: make(map[string]bool),
+		subtopicsMap: make(map[string]Subtopic),
 	}
 }
 
-// Get returns a bool value for the given key (id) to inform that the subtopic id exists
-func (t *SubtopicsIDs) Get(key string) bool {
+// Get returns subtopic for given key (id)
+func (t *SubtopicsIDs) Get(key string) Subtopic {
 	t.mutex.RLock()
 	defer t.mutex.RUnlock()
 
 	return t.subtopicsMap[key]
+}
+
+// CheckTopicIDExsits returns subtopic for given key (id)
+func (t *SubtopicsIDs) CheckTopicIDExsits(key string) bool {
+	t.mutex.RLock()
+	defer t.mutex.RUnlock()
+
+	if _, ok := t.subtopicsMap[key]; !ok {
+		return false
+	}
+
+	return true
 }
 
 // GetSubtopicsIDsQuery gets the subtopics ID query for a topic
@@ -44,13 +61,13 @@ func (t *SubtopicsIDs) GetSubtopicsIDsQuery() string {
 }
 
 // AppendSubtopicID appends the subtopic id to the map stored in SubtopicsIDs with consideration to mutex locking
-func (t *SubtopicsIDs) AppendSubtopicID(id string) {
+func (t *SubtopicsIDs) AppendSubtopicID(id string, subtopic Subtopic) {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
 
 	if t.subtopicsMap == nil {
-		t.subtopicsMap = make(map[string]bool)
+		t.subtopicsMap = make(map[string]Subtopic)
 	}
 
-	t.subtopicsMap[id] = true
+	t.subtopicsMap[id] = subtopic
 }

--- a/cache/subtopic.go
+++ b/cache/subtopic.go
@@ -10,7 +10,7 @@ import (
 // and to check if the subtopic id given by a user exists
 type Subtopics struct {
 	mutex        *sync.RWMutex
-	SubtopicsMap map[string]Subtopic
+	subtopicsMap map[string]Subtopic
 }
 
 type Subtopic struct {
@@ -23,7 +23,7 @@ type Subtopic struct {
 func NewSubTopicsMap() *Subtopics {
 	return &Subtopics{
 		mutex:        &sync.RWMutex{},
-		SubtopicsMap: make(map[string]Subtopic),
+		subtopicsMap: make(map[string]Subtopic),
 	}
 }
 
@@ -32,7 +32,23 @@ func (t *Subtopics) Get(key string) Subtopic {
 	t.mutex.RLock()
 	defer t.mutex.RUnlock()
 
-	return t.SubtopicsMap[key]
+	return t.subtopicsMap[key]
+}
+
+// GetSubtopics returns an array of subtopics
+func (t *Subtopics) GetSubtopics(key string) (subtopics []Subtopic) {
+	if t.subtopicsMap == nil {
+		return
+	}
+
+	t.mutex.RLock()
+	defer t.mutex.RUnlock()
+
+	for _, subtopic := range t.subtopicsMap {
+		subtopics = append(subtopics, subtopic)
+	}
+
+	return subtopics
 }
 
 // CheckTopicIDExists returns subtopic for given key (id)
@@ -40,7 +56,7 @@ func (t *Subtopics) CheckTopicIDExists(key string) bool {
 	t.mutex.RLock()
 	defer t.mutex.RUnlock()
 
-	if _, ok := t.SubtopicsMap[key]; !ok {
+	if _, ok := t.subtopicsMap[key]; !ok {
 		return false
 	}
 
@@ -52,9 +68,9 @@ func (t *Subtopics) GetSubtopicsIDsQuery() string {
 	t.mutex.RLock()
 	defer t.mutex.RUnlock()
 
-	ids := make([]string, 0, len(t.SubtopicsMap))
+	ids := make([]string, 0, len(t.subtopicsMap))
 
-	for id := range t.SubtopicsMap {
+	for id := range t.subtopicsMap {
 		ids = append(ids, id)
 	}
 
@@ -66,9 +82,9 @@ func (t *Subtopics) AppendSubtopicID(id string, subtopic Subtopic) {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
 
-	if t.SubtopicsMap == nil {
-		t.SubtopicsMap = make(map[string]Subtopic)
+	if t.subtopicsMap == nil {
+		t.subtopicsMap = make(map[string]Subtopic)
 	}
 
-	t.SubtopicsMap[id] = subtopic
+	t.subtopicsMap[id] = subtopic
 }

--- a/cache/subtopic.go
+++ b/cache/subtopic.go
@@ -5,41 +5,42 @@ import (
 	"sync"
 )
 
-// SubtopicsIDs contains a list of subtopics in map form with addition to mutex locking
+// Subtopics contains a list of subtopics in map form with addition to mutex locking
 // The subtopicsMap is used to keep a record of subtopics to be later used to generate the subtopics id `query` for a topic
 // and to check if the subtopic id given by a user exists
-type SubtopicsIDs struct {
+type Subtopics struct {
 	mutex        *sync.RWMutex
-	subtopicsMap map[string]Subtopic
+	SubtopicsMap map[string]Subtopic
 }
 
 type Subtopic struct {
+	ID              string
 	LocaliseKeyName string
 	ReleaseDate     string
 }
 
 // GetNewSubTopicsMap creates a new subtopics id map to store subtopic ids with addition to mutex locking
-func NewSubTopicsMap() *SubtopicsIDs {
-	return &SubtopicsIDs{
+func NewSubTopicsMap() *Subtopics {
+	return &Subtopics{
 		mutex:        &sync.RWMutex{},
-		subtopicsMap: make(map[string]Subtopic),
+		SubtopicsMap: make(map[string]Subtopic),
 	}
 }
 
 // Get returns subtopic for given key (id)
-func (t *SubtopicsIDs) Get(key string) Subtopic {
+func (t *Subtopics) Get(key string) Subtopic {
 	t.mutex.RLock()
 	defer t.mutex.RUnlock()
 
-	return t.subtopicsMap[key]
+	return t.SubtopicsMap[key]
 }
 
-// CheckTopicIDExsits returns subtopic for given key (id)
-func (t *SubtopicsIDs) CheckTopicIDExsits(key string) bool {
+// CheckTopicIDExists returns subtopic for given key (id)
+func (t *Subtopics) CheckTopicIDExists(key string) bool {
 	t.mutex.RLock()
 	defer t.mutex.RUnlock()
 
-	if _, ok := t.subtopicsMap[key]; !ok {
+	if _, ok := t.SubtopicsMap[key]; !ok {
 		return false
 	}
 
@@ -47,13 +48,13 @@ func (t *SubtopicsIDs) CheckTopicIDExsits(key string) bool {
 }
 
 // GetSubtopicsIDsQuery gets the subtopics ID query for a topic
-func (t *SubtopicsIDs) GetSubtopicsIDsQuery() string {
+func (t *Subtopics) GetSubtopicsIDsQuery() string {
 	t.mutex.RLock()
 	defer t.mutex.RUnlock()
 
-	ids := make([]string, 0, len(t.subtopicsMap))
+	ids := make([]string, 0, len(t.SubtopicsMap))
 
-	for id := range t.subtopicsMap {
+	for id := range t.SubtopicsMap {
 		ids = append(ids, id)
 	}
 
@@ -61,13 +62,13 @@ func (t *SubtopicsIDs) GetSubtopicsIDsQuery() string {
 }
 
 // AppendSubtopicID appends the subtopic id to the map stored in SubtopicsIDs with consideration to mutex locking
-func (t *SubtopicsIDs) AppendSubtopicID(id string, subtopic Subtopic) {
+func (t *Subtopics) AppendSubtopicID(id string, subtopic Subtopic) {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
 
-	if t.subtopicsMap == nil {
-		t.subtopicsMap = make(map[string]Subtopic)
+	if t.SubtopicsMap == nil {
+		t.SubtopicsMap = make(map[string]Subtopic)
 	}
 
-	t.subtopicsMap[id] = subtopic
+	t.SubtopicsMap[id] = subtopic
 }

--- a/cache/subtopic_test.go
+++ b/cache/subtopic_test.go
@@ -8,6 +8,21 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
+var (
+	subtopic1 = Subtopic{
+		LocaliseKeyName: "International Migration",
+		ReleaseDate:     "2022-10-10T08:30:00Z",
+	}
+	subtopic2 = Subtopic{
+		LocaliseKeyName: "Age",
+		ReleaseDate:     "2022-11-09T09:30:00Z",
+	}
+	subtopic3 = Subtopic{
+		LocaliseKeyName: "Health",
+		ReleaseDate:     "2023-01-07T09:30:00Z",
+	}
+)
+
 func TestAppendSubtopicID(t *testing.T) {
 	t.Parallel()
 
@@ -15,10 +30,10 @@ func TestAppendSubtopicID(t *testing.T) {
 		subtopicIDsStore := NewSubTopicsMap()
 
 		Convey("When AppendSubtopicID is called", func() {
-			subtopicIDsStore.AppendSubtopicID("1234")
+			subtopicIDsStore.AppendSubtopicID("1234", subtopic1)
 
 			Convey("Then the new subtopic id should be added to the map", func() {
-				So(subtopicIDsStore.Get("1234"), ShouldBeTrue)
+				So(subtopicIDsStore.Get("1234"), ShouldResemble, subtopic1)
 			})
 		})
 	})
@@ -28,25 +43,29 @@ func TestAppendSubtopicID(t *testing.T) {
 		subtopicIDsStore.subtopicsMap = nil
 
 		Convey("When AppendSubtopicID is called", func() {
-			subtopicIDsStore.AppendSubtopicID("1234")
+			subtopicIDsStore.AppendSubtopicID("1234", subtopic1)
 
 			Convey("Then the new subtopic id should be added to the map", func() {
-				So(subtopicIDsStore.Get("1234"), ShouldBeTrue)
+				So(subtopicIDsStore.Get("1234"), ShouldResemble, subtopic1)
 			})
 		})
 	})
 
 	Convey("Given an existing SubtopicsIDs object with data", t, func() {
 		subtopicIDsStore := NewSubTopicsMap()
-		subtopicIDsStore.subtopicsMap = map[string]bool{
-			"1234": true,
+		subtopicIDsStore.subtopicsMap = map[string]Subtopic{
+			"1234": subtopic1,
 		}
 
 		Convey("When AppendSubtopicID is called", func() {
-			subtopicIDsStore.AppendSubtopicID("5678")
+			subtopicIDsStore.AppendSubtopicID("5678", subtopic2)
 
 			Convey("Then the new subtopic id should be added to the map", func() {
-				So(subtopicIDsStore.Get("5678"), ShouldBeTrue)
+				So(subtopicIDsStore.Get("5678"), ShouldResemble, subtopic2)
+			})
+
+			Convey("And the existing subtopic `1234` should still exist in map", func() {
+				So(subtopicIDsStore.Get("1234"), ShouldResemble, subtopic1)
 			})
 		})
 	})
@@ -55,15 +74,15 @@ func TestAppendSubtopicID(t *testing.T) {
 		subtopicIDsStore := NewSubTopicsMap()
 
 		Convey("When AppendSubtopicID is called", func() {
-			go subtopicIDsStore.AppendSubtopicID("5678")
-			go subtopicIDsStore.AppendSubtopicID("9123")
+			go subtopicIDsStore.AppendSubtopicID("5678", subtopic2)
+			go subtopicIDsStore.AppendSubtopicID("9123", subtopic3)
 
 			Convey("Then the new subtopic ids should be added", func() {
 				// Wait for the goroutines to finish
 				time.Sleep(300 * time.Millisecond)
 
-				So(subtopicIDsStore.Get("5678"), ShouldBeTrue)
-				So(subtopicIDsStore.Get("9123"), ShouldBeTrue)
+				So(subtopicIDsStore.Get("5678"), ShouldResemble, subtopic2)
+				So(subtopicIDsStore.Get("9123"), ShouldResemble, subtopic3)
 			})
 		})
 	})
@@ -87,9 +106,9 @@ func TestGetSubtopicsIDsQuery(t *testing.T) {
 	Convey("Given a list of subtopics", t, func() {
 		subtopicIDsStore := SubtopicsIDs{
 			mutex: &sync.RWMutex{},
-			subtopicsMap: map[string]bool{
-				"1234": true,
-				"5678": true,
+			subtopicsMap: map[string]Subtopic{
+				"1234": subtopic1,
+				"5678": subtopic2,
 			},
 		}
 

--- a/cache/subtopic_test.go
+++ b/cache/subtopic_test.go
@@ -40,7 +40,7 @@ func TestAppendSubtopicID(t *testing.T) {
 
 	Convey("Given a nil map in the SubtopicsIDs object", t, func() {
 		subtopicIDsStore := NewSubTopicsMap()
-		subtopicIDsStore.subtopicsMap = nil
+		subtopicIDsStore.SubtopicsMap = nil
 
 		Convey("When AppendSubtopicID is called", func() {
 			subtopicIDsStore.AppendSubtopicID("1234", subtopic1)
@@ -53,7 +53,7 @@ func TestAppendSubtopicID(t *testing.T) {
 
 	Convey("Given an existing SubtopicsIDs object with data", t, func() {
 		subtopicIDsStore := NewSubTopicsMap()
-		subtopicIDsStore.subtopicsMap = map[string]Subtopic{
+		subtopicIDsStore.SubtopicsMap = map[string]Subtopic{
 			"1234": subtopic1,
 		}
 
@@ -104,9 +104,9 @@ func TestGetSubtopicsIDsQuery(t *testing.T) {
 	})
 
 	Convey("Given a list of subtopics", t, func() {
-		subtopicIDsStore := SubtopicsIDs{
+		subtopicIDsStore := Subtopics{
 			mutex: &sync.RWMutex{},
-			subtopicsMap: map[string]Subtopic{
+			SubtopicsMap: map[string]Subtopic{
 				"1234": subtopic1,
 				"5678": subtopic2,
 			},

--- a/cache/subtopic_test.go
+++ b/cache/subtopic_test.go
@@ -40,7 +40,7 @@ func TestAppendSubtopicID(t *testing.T) {
 
 	Convey("Given a nil map in the SubtopicsIDs object", t, func() {
 		subtopicIDsStore := NewSubTopicsMap()
-		subtopicIDsStore.SubtopicsMap = nil
+		subtopicIDsStore.subtopicsMap = nil
 
 		Convey("When AppendSubtopicID is called", func() {
 			subtopicIDsStore.AppendSubtopicID("1234", subtopic1)
@@ -53,7 +53,7 @@ func TestAppendSubtopicID(t *testing.T) {
 
 	Convey("Given an existing SubtopicsIDs object with data", t, func() {
 		subtopicIDsStore := NewSubTopicsMap()
-		subtopicIDsStore.SubtopicsMap = map[string]Subtopic{
+		subtopicIDsStore.subtopicsMap = map[string]Subtopic{
 			"1234": subtopic1,
 		}
 
@@ -106,7 +106,7 @@ func TestGetSubtopicsIDsQuery(t *testing.T) {
 	Convey("Given a list of subtopics", t, func() {
 		subtopicIDsStore := Subtopics{
 			mutex: &sync.RWMutex{},
-			SubtopicsMap: map[string]Subtopic{
+			subtopicsMap: map[string]Subtopic{
 				"1234": subtopic1,
 				"5678": subtopic2,
 			},

--- a/cache/topic.go
+++ b/cache/topic.go
@@ -26,8 +26,8 @@ type Topic struct {
 	LocaliseKeyName string
 	// Query is a comma separated string of topic id and its subtopic ids which will be used by the controller to create the query
 	Query string
-	// List is a map[string]bool which contains the topic id and its subtopic ids which will be used to check if the topic id given by the user exists
-	List *SubtopicsIDs
+	// List is a map[string]Subtopics which contains the topic id and a list of it's subtopics
+	List *Subtopics
 }
 
 // NewTopicCache create a topic cache object to be used in the service which will update at every updateInterval

--- a/data/topic_filter.go
+++ b/data/topic_filter.go
@@ -3,6 +3,7 @@ package data
 import (
 	"context"
 	"net/url"
+	"sort"
 	"strings"
 
 	searchCli "github.com/ONSdigital/dp-api-clients-go/v2/site-search"
@@ -13,24 +14,58 @@ import (
 
 // Topic represents a topic filter on the search page
 type Topic struct {
-	LocaliseKeyName string `json:"localise_key"`
+	Count           int        `json:"count"`
+	LocaliseKeyName string     `json:"localise_key"`
+	Query           string     `json:"query"`
+	ShowInWebUI     bool       `json:"show_in_web_ui"`
+	Subtopics       []Subtopic `json:"subtopics"`
+}
+
+// Subtopic represents a subtopic filter on the search page
+type Subtopic struct {
 	Count           int    `json:"count"`
+	LocaliseKeyName string `json:"localise_key"`
 	Query           string `json:"query"`
 	ShowInWebUI     bool   `json:"show_in_web_ui"`
 }
 
 // GetTopicCategories returns the topic filters to be displayed on the search page.
 // Please note that only census topic filter is being returned
-func GetTopicCategories(censusTopicCache *cache.Topic, countResp searchCli.Response) []Topic {
+func GetTopics(censusTopicCache *cache.Topic, countResp searchCli.Response) []Topic {
+	var cachedSubtopics []cache.Subtopic
+	if censusTopicCache != nil || censusTopicCache.List != nil {
+		cachedSubtopics = censusTopicCache.List.GetSubtopics(censusTopicCache.LocaliseKeyName)
+	}
+
+	subtopics := make([]Subtopic, 0, len(cachedSubtopics))
+	for i := range cachedSubtopics {
+		// Do not add census topic to subtopics
+		if cachedSubtopics[i].ID == censusTopicCache.ID {
+			continue
+		}
+
+		subtopics = append(subtopics, Subtopic{
+			LocaliseKeyName: cachedSubtopics[i].LocaliseKeyName,
+			Query:           cachedSubtopics[i].ID,
+			ShowInWebUI:     true,
+		})
+	}
+
+	// Order subtopics alphabetically
+	sort.Slice(subtopics, func(i, j int) bool {
+		return subtopics[i].LocaliseKeyName < subtopics[j].LocaliseKeyName
+	})
+
 	censusTopic := Topic{
 		LocaliseKeyName: censusTopicCache.LocaliseKeyName,
 		Query:           censusTopicCache.ID,
 		ShowInWebUI:     true,
+		Subtopics:       subtopics,
 	}
 
 	// if censusTopicCache has not been updated, don't show census topic filter in web UI
 	if censusTopicCache.LocaliseKeyName != "" {
-		censusTopic.Count = getCensusTopicCount(censusTopicCache, countResp)
+		censusTopic = addTopicCounts(censusTopic, countResp)
 	} else {
 		censusTopic.ShowInWebUI = false
 	}
@@ -38,14 +73,22 @@ func GetTopicCategories(censusTopicCache *cache.Topic, countResp searchCli.Respo
 	return []Topic{censusTopic}
 }
 
-func getCensusTopicCount(censusTopicCache *cache.Topic, countResp searchCli.Response) (count int) {
+func addTopicCounts(censusTopic Topic, countResp searchCli.Response) Topic {
 	for i := range countResp.Topics {
-		if censusTopicCache.ID == countResp.Topics[i].Type {
-			count = countResp.Topics[i].Count
-			return
+		if censusTopic.Query == countResp.Topics[i].Type {
+			censusTopic.Count = countResp.Topics[i].Count
+			continue
+		}
+
+		for j := range censusTopic.Subtopics {
+			if censusTopic.Subtopics[j].Query == countResp.Topics[i].Type {
+				censusTopic.Subtopics[j].Count = countResp.Topics[i].Count
+				continue
+			}
 		}
 	}
-	return
+
+	return censusTopic
 }
 
 // reviewTopicFilters retrieves subtopic ids from query, checks if they are one of the census subtopics, and updates validatedQueryParams

--- a/data/topic_filter.go
+++ b/data/topic_filter.go
@@ -62,7 +62,7 @@ func reviewTopicFilters(ctx context.Context, urlQuery url.Values, validatedQuery
 			continue
 		}
 
-		if ok := censusTopicCache.List.CheckTopicIDExsits(topicFilterQuery); !ok {
+		if ok := censusTopicCache.List.CheckTopicIDExists(topicFilterQuery); !ok {
 			err := errs.ErrTopicNotFound
 			logData := log.Data{"subtopic id not found": topicFilterQuery}
 			log.Error(ctx, "failed to find subtopic id in census topic data", err, logData)

--- a/data/topic_filter.go
+++ b/data/topic_filter.go
@@ -62,8 +62,7 @@ func reviewTopicFilters(ctx context.Context, urlQuery url.Values, validatedQuery
 			continue
 		}
 
-		found := censusTopicCache.List.Get(topicFilterQuery)
-		if !found {
+		if ok := censusTopicCache.List.CheckTopicIDExsits(topicFilterQuery); !ok {
 			err := errs.ErrTopicNotFound
 			logData := log.Data{"subtopic id not found": topicFilterQuery}
 			log.Error(ctx, "failed to find subtopic id in census topic data", err, logData)

--- a/data/topic_filter_test.go
+++ b/data/topic_filter_test.go
@@ -28,7 +28,7 @@ func TestGetTopicCategories(t *testing.T) {
 		mockCensusTopic := cache.GetMockCensusTopic()
 
 		Convey("When GetTopicCategories is called", func() {
-			topicCategories := GetTopicCategories(mockCensusTopic, mockSearchCliResponse)
+			topicCategories := GetTopics(mockCensusTopic, mockSearchCliResponse)
 
 			Convey("Then a list of topic categories with count should be returned", func() {
 				So(topicCategories, ShouldNotBeEmpty)
@@ -45,7 +45,7 @@ func TestGetTopicCategories(t *testing.T) {
 		mockCensusTopic := cache.GetMockCensusTopic()
 
 		Convey("When GetTopicCategories is called", func() {
-			topicCategories := GetTopicCategories(mockCensusTopic, mockSearchCliResponse)
+			topicCategories := GetTopics(mockCensusTopic, mockSearchCliResponse)
 
 			Convey("Then a list of topic categories with 0 count should be returned", func() {
 				So(topicCategories, ShouldNotBeEmpty)
@@ -67,7 +67,7 @@ func TestGetTopicCategories(t *testing.T) {
 		}
 
 		Convey("When GetTopicCategories is called", func() {
-			topicCategories := GetTopicCategories(mockCensusTopic, mockSearchCliResponse)
+			topicCategories := GetTopics(mockCensusTopic, mockSearchCliResponse)
 
 			Convey("Then we hide the census topic filter in web UI", func() {
 				So(topicCategories, ShouldNotBeEmpty)

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -44,6 +44,8 @@ func read(w http.ResponseWriter, req *http.Request, cfg *config.Config, zc Zebed
 		return
 	}
 
+	log.Info(ctx, "got topic cache", log.Data{"cache": censusTopicCache})
+
 	// get cached navigation data
 	navigationCache, err := cacheList.Navigation.GetNavigationData(ctx, lang)
 	if err != nil {

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -44,8 +44,6 @@ func read(w http.ResponseWriter, req *http.Request, cfg *config.Config, zc Zebed
 		return
 	}
 
-	log.Info(ctx, "got topic cache", log.Data{"cache": censusTopicCache})
-
 	// get cached navigation data
 	navigationCache, err := cacheList.Navigation.GetNavigationData(ctx, lang)
 	if err != nil {
@@ -187,7 +185,7 @@ func getCategoriesTypesCount(ctx context.Context, accessToken, collectionID stri
 	}
 
 	categories := data.GetCategories()
-	topicCategories := data.GetTopicCategories(censusTopicCache, countResp)
+	topicCategories := data.GetTopics(censusTopicCache, countResp)
 
 	setCountToCategories(ctx, countResp, categories)
 

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -47,8 +47,14 @@ var (
 		ID:              "1234",
 		LocaliseKeyName: "Census",
 		Query:           "1234",
+		List:            &cache.Subtopics{},
 	}
 )
+
+// func setupTopicCache(cacheTopic *cache.Topic) {
+// 	cacheTopic.UpdateCensusTopic{}
+// 	cacheTopic.List.AppendSubtopicID("5678", cache.Subtopic{ID: "5678", LocaliseKeyName: "Ageing", ReleaseDate: "2022-10-10T09:30:00Z"})
+// }
 
 func TestUnitReadHandlerSuccess(t *testing.T) {
 	t.Parallel()

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -347,6 +347,23 @@ func mapTopicFilters(cfg *config.Config, page *model.SearchPage, topicCategories
 		}
 
 		topicFilters[i] = topicFilter
+
+		for j := range topicCategories[i].Subtopics {
+			if !topicCategories[i].Subtopics[j].ShowInWebUI {
+				continue
+			}
+			var subtopicFilter model.TopicFilter
+
+			subtopicFilter.LocaliseKeyName = topicCategories[i].Subtopics[j].LocaliseKeyName
+			subtopicFilter.NumberOfResults = topicCategories[i].Subtopics[j].Count
+			subtopicFilter.Query = topicCategories[i].Subtopics[j].Query
+
+			if topicCategories[i].Subtopics[j].Query == queryParams.TopicFilter {
+				subtopicFilter.IsChecked = true
+			}
+
+			topicFilters[i].Types = append(topicFilters[i].Types, subtopicFilter)
+		}
 	}
 
 	page.Data.TopicFilters = topicFilters

--- a/model/search.go
+++ b/model/search.go
@@ -31,10 +31,11 @@ type Filter struct {
 
 // TopicFilter respresents all the topic filter information needed by templates
 type TopicFilter struct {
-	LocaliseKeyName string `json:"localise_key_name,omitempty"`
-	Query           string `json:"query,omitempty"`
-	IsChecked       bool   `json:"is_checked,omitempty"`
-	NumberOfResults int    `json:"number_of_results,omitempty"`
+	LocaliseKeyName string        `json:"localise_key_name,omitempty"`
+	Query           string        `json:"query,omitempty"`
+	IsChecked       bool          `json:"is_checked,omitempty"`
+	NumberOfResults int           `json:"number_of_results,omitempty"`
+	Types           []TopicFilter `json:"subtopics,omitempty"`
 }
 
 // Sort represents all the information of sorting related to the search page


### PR DESCRIPTION
### What

- Topic cache updated to include subtopic data, labels and release dates as well as ids
- Search results page updated to display the topic filters (english only as this is what is stored in topics API)

### How to review

- Sanity check changes

### Who can review

Anyone
