### PR TITLE
render search page when user inputs  invalid query

### DIFF
--- a/apperrors/errors.go
+++ b/apperrors/errors.go
@@ -23,6 +23,7 @@ var (
 
 	// ErrMapForRenderBeforeAPICalls is a list of errors which leads to the search page being rendered before making any API calls
 	ErrMapForRenderBeforeAPICalls = map[error]bool{
-		ErrInvalidQueryString: true,
+		ErrInvalidQueryString:           true,
+		ErrInvalidQueryCharLengthString: true,
 	}
 )

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -83,7 +83,7 @@ func read(w http.ResponseWriter, req *http.Request, cfg *config.Config, zc Zebed
 
 	var (
 		homepageResp zebedeeCli.HomepageContent
-		searchResp   *searchModels.SearchResponse
+		searchResp   = &searchModels.SearchResponse{}
 
 		categories      []data.Category
 		topicCategories []data.Topic


### PR DESCRIPTION
### What

Search is not rendering a search page when there is an invalid query (less than 2 characters). Search should render a blank search page (not a zero results page).

### How to review

See that code makes sense.

### Who can review

Anyone.
