### PR TITLE
Fix handling of census checkbox

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,7 @@ run:
   concurrency: 4
 
   # timeout for analysis, e.g. 30s, 5m, default is 1m
-  timeout: 5m
+  timeout: 10m
 linters-settings:
   govet:
     check-shadowing: true

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -226,7 +226,10 @@ func mapTopicFilters(cfg *config.Config, page *model.SearchPage, topicCategories
 		return
 	}
 
-	topicsQueryParam := strings.Split(queryParams.TopicFilter, ",")
+	var topicsQueryParam []string
+	if queryParams.TopicFilter != "" {
+		topicsQueryParam = strings.Split(queryParams.TopicFilter, ",")
+	}
 
 	mapTopicQueryParams := make(map[string]bool)
 	for i := range topicsQueryParam {


### PR DESCRIPTION
### What

See title

Previous split on empty string resulted in 1 item being added to the array used for determining if the "census" checkbox should be checked; this resulted in the census checkbox always being checked even if no topic filters were set. See image below for problem this PR fixes

<img width="1328" alt="Screenshot 2023-02-07 at 14 02 59" src="https://user-images.githubusercontent.com/7114615/217266657-3a0d6fc5-d32b-4298-bbab-b16f55ea7bb8.png">

### How to review

Sanity check changes

### Who can review

Anyone


