### PR TITLE
only show count if there is a query param

### DIFF
--- a/assets/templates/partials/summary.tmpl
+++ b/assets/templates/partials/summary.tmpl
@@ -10,7 +10,7 @@
                 </span>
             {{ end }}
         {{else}} {{ localise "Results" $lang 1 }} {{end}} 
-        {{ localise "For" $lang 1 }}
+        {{ if .Data.Query}} {{ localise "For" $lang 1 }} {{ end }}
     </span>
     <span class="search__summary__query">{{ .Data.Query}}</span>
     {{ $len := len .Data.Response.AdditionalSuggestions}}


### PR DESCRIPTION
### What

Only show "Results for" when there is a query parameter otherwise "Results" should be displayed

### How to review

<img width="1045" alt="Screenshot 2023-02-07 at 15 16 26" src="https://user-images.githubusercontent.com/16807393/217285266-57f920ea-b480-444a-9fc8-2739831ff1ae.png">


### Who can review

Anyone
