### PR TITLE
Add population type to dataset finder rendering

### DIFF
--- a/assets/templates/partials/filter.tmpl
+++ b/assets/templates/partials/filter.tmpl
@@ -15,7 +15,7 @@
             <summary class="ons-collapsible__heading ons-js-collapsible-heading">
                 <h2 class="ons-collapsible__title">
                     <legend class="block">
-                        {{ localise "Topic" $lang 2 }}
+                        {{ localise "Topic" $lang 4 }}
                     </legend>
                 </h2>
                 <span class="ons-collapsible__icon">

--- a/assets/templates/partials/results.tmpl
+++ b/assets/templates/partials/results.tmpl
@@ -3,6 +3,8 @@
 {{ $itemsPerPage := .Data.Pagination.Limit }}
 {{ $totalSearchPosition := multiply (subtract $currentPage 1) $itemsPerPage }}
 {{ $response := .Data.Response }}
+{{ $datasetFinder := .Data.PopulationTypeFilter }}
+
 <div id="results">
     <div id="results-loading" class="ons-panel ons-panel--info ons-panel--no-title hide">
         <span class="ons-u-vh">Important information: </span>
@@ -34,20 +36,35 @@
                     {{ .Description.Edition | safeHTML }}
                 </a>
             </h3>
-            {{if eq $item.Type.Type `product_page`}}
-                <p class="search__results__meta font-size--16">
-                    <b>Topic</b>
-                </p>
-            {{else}}
-                <p class="search__results__meta font-size--16">
-                    <b>{{ localise "ReleasedOn" $lang 1 }}:</b> {{dateFormat .Description.ReleaseDate}}
-                    |
-                    <b>{{ localise .Type.LocaliseKeyName $lang 1 }}</b>
-                </p>
-            {{end}}
+            {{ if not $datasetFinder }} 
+                {{ if eq $item.Type.Type `product_page` }}
+                    <p class="search__results__meta font-size--16">
+                        <b>Topic</b>
+                    </p>
+                {{ else }}
+                    <p class="search__results__meta font-size--16">
+                        <b>{{ localise "ReleasedOn" $lang 1 }}:</b> {{dateFormat .Description.ReleaseDate}}
+                        |
+                        <b>{{ localise .Type.LocaliseKeyName $lang 1 }}</b>
+                    </p>
+                {{ end }}
+            {{ end }}
             <p class="search__results__summary font-size--16">
                 {{ if .Description.Highlight.Summary }} {{ .Description.Highlight.Summary | safeHTML }} {{ else }} {{ .Description.Summary | safeHTML }} {{ end }}
             </p>
+            {{ if $datasetFinder }} 
+                {{ $dlTermClasses := "ons-metadata__term ons-grid__col ons-col-3@m font-size--16" }}
+                {{ $dlValueClasses := "ons-metadata__value ons-grid__col ons-col-9@m font-size--16" }}
+
+                <dl class="ons-metadata ons-metadata__list ons-u-cf ons-grid ons-grid--gutterless font-size--16">
+                    <dt class="{{ $dlTermClasses }}">{{ localise "ReleasedOn" $lang 1 }}:</dt>
+                    <dd class="{{ $dlValueClasses }}">{{dateFormat .Description.ReleaseDate}}</dd>
+                    {{ if .Dataset.PopulationType }}
+                        <dt class="{{ $dlTermClasses }}">{{ localise "PopulationTypes" $lang 1 }}:</dt>
+                        <dd class="{{ $dlValueClasses }}">{{ .Dataset.PopulationType }}</dd>
+                    {{ end }}
+                </dl>
+            {{ end }}
             {{if eq $item.Type.Type `product_page`}}
                 <p class="search__results__summary--product-page font-size--16">
                     View all <a href="{{ .URI }}#datasets">datasets</a> or <a href="{{ .URI }}#publications">publications</a> related to 

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -164,6 +164,7 @@ func mapResponseItems(page *model.SearchPage, respC *searchModels.SearchResponse
 		item.Type.LocaliseKeyName = data.GetGroupLocaliseKey(respC.Items[i].DataType)
 
 		item.URI = respC.Items[i].URI
+		item.Dataset.PopulationType = respC.Items[i].PopulationType
 
 		itemPage = append(itemPage, item)
 	}

--- a/model/search.go
+++ b/model/search.go
@@ -102,6 +102,7 @@ type ContentType struct {
 // ContentItem represents each search result
 type ContentItem struct {
 	Type        ContentItemType `json:"type"`
+	Dataset     Dataset         `json:"dataset"`
 	Description Description     `json:"description"`
 	URI         string          `json:"uri"`
 	Matches     *Matches        `json:"matches,omitempty"`
@@ -111,6 +112,11 @@ type ContentItem struct {
 type ContentItemType struct {
 	Type            string `json:"type"`
 	LocaliseKeyName string `json:"localise_key"`
+}
+
+// Dataset represents additional dataset fields
+type Dataset struct {
+	PopulationType string `json:"population_type,omitempty"`
 }
 
 // Description represents each search result description


### PR DESCRIPTION
### What

Added different rendering if it's on the census dataset finder page and added Population Type to the render. 

### How to review

Connect search controller to sandbox search api and view the census dataset finder - also ensure normal search is not affected. 

### Who can review

Not me. 