### PR TITLE
remove attribute

### DIFF
--- a/assets/templates/partials/filter.tmpl
+++ b/assets/templates/partials/filter.tmpl
@@ -98,7 +98,6 @@
                                     <input type="checkbox" id="group-{{ $index }}"
                                         class="ons-checkbox__input ons-js-checkbox"
                                         value="{{ print $topFilter.FilterKey }}" categoryChildren="{{ print $topFilter.FilterKey }}" aria-controls="group-{{ $index }}-other-wrap"
-                                        aria-haspopup="true"
                                         data-gtm-label="{{ $topFilter.LocaliseKeyName }}"
                                         {{ if $topFilter.IsChecked }}
                                             checked


### PR DESCRIPTION
### What

The design system adds `aria-expanded` to any revealed checkbox which has the attribute `aria-haspopup` however this causes an [accessibility failure](https://www.w3.org/TR/2017/REC-wai-aria-1.1-20171214/#aria-expanded). 

### How to review

See that there are no failures when running through an accessibility tool. 

### Who can review

!me. 
