### PR TITLE
Add CDID and DatasetID to timeseries explorer

### DIFF
--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -457,3 +457,13 @@ one = "Search results for publications"
 description = "Data results. Current page."
 other = "Data results. Current page."
 one = "Data results. Current page."
+
+[SeriesID]
+description = "Series ID"
+other = "ID y gyfres"
+one = "ID y gyfres"
+
+[DatasetID]
+description = "Series ID"
+other = "ID y set ddata"
+one = "ID y set ddata"

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -458,3 +458,13 @@ one = "Search results for publications"
 description = "Data results. Current page."
 other = "Data results. Current page."
 one = "Data results. Current page."
+
+[SeriesID]
+description = "Series ID"
+other = "Series ID"
+one = "Series ID"
+
+[DatasetID]
+description = "Dataset ID"
+other = "Dataset ID"
+one = "Dataset ID"

--- a/assets/templates/partials/data-aggregation-results.tmpl
+++ b/assets/templates/partials/data-aggregation-results.tmpl
@@ -3,7 +3,6 @@
 {{ $itemsPerPage := .Data.Pagination.Limit }}
 {{ $totalSearchPosition := multiply (subtract $currentPage 1) $itemsPerPage }}
 {{ $response := .Data.Response }}
-{{ $datasetFinder := .Data.PopulationTypeFilter }}
 {{ $enabledTimeSeriesExport := .Data.EnableTimeSeriesExport }}
 
 <div id="results">
@@ -67,35 +66,33 @@
                         </a>
                     {{end}}
                 </h3>
-                {{ if not $datasetFinder }} 
-                    {{ if eq $item.Type.Type `product_page` }}
-                        <p class="search__results__meta font-size--16">
-                            <b>{{ localise "Topic" $lang 1 }}</b>
-                        </p>
-                    {{ else }}
-                        <p class="search__results__meta font-size--16">
-                            <b>{{ localise "ReleasedOn" $lang 1 }}:</b> {{ dateFormat .Description.ReleaseDate }}
-                            |
-                            <b>{{ localise .Type.LocaliseKeyName $lang 1 }}</b>
-                        </p>
+                <ul class="ons-document-list__item-metadata">
+                    <li class="ons-document-list__item-attribute">
+                        <span class="ons-u-fw-b">{{ localise "ReleasedOn" $lang 1 }}:</span>
+                        <span> {{ dateFormat .Description.ReleaseDate }}</span>
+                    </li>
+                    {{/* Don't show type on timeseries page as they're all timeseries */}}
+                    {{ if not $enabledTimeSeriesExport }} 
+                    <li class="ons-document-list__item-attribute">
+                        <span class="ons-u-fw-b">{{ localise .Type.LocaliseKeyName $lang 1 }}</span>
+                    </li>
                     {{ end }}
-                {{ end }}
+                    {{ if .Description.CDID }}
+                    <li class="ons-document-list__item-attribute">
+                        <span class="ons-u-fw-b">{{ localise "SeriesID" $lang 1 }}:</span>
+                        <span> {{ dateFormat .Description.CDID }}</span>
+                    </li>
+                    {{ end }}
+                    {{ if .Description.DatasetID }}
+                    <li class="ons-document-list__item-attribute">
+                        <span class="ons-u-fw-b">{{ localise "DatasetID" $lang 1 }}:</span>
+                        <span> {{ dateFormat .Description.DatasetID }}</span>
+                    </li>
+                    {{ end }}
+                </ul>
                 <p class="search__results__summary font-size--16">
                     {{ if .Description.Highlight.Summary }} {{ .Description.Highlight.Summary | safeHTML }} {{ else }} {{ .Description.Summary | safeHTML }} {{ end }}
                 </p>
-                {{ if $datasetFinder }} 
-                    {{ $dlTermClasses := "ons-metadata__term ons-grid__col ons-col-3@m font-size--16" }}
-                    {{ $dlValueClasses := "ons-metadata__value ons-grid__col ons-col-9@m font-size--16" }}
-
-                    <dl class="ons-metadata ons-metadata__list ons-u-cf ons-grid ons-grid--gutterless font-size--16">
-                        <dt class="{{ $dlTermClasses }}">{{ localise "ReleasedOn" $lang 1 }}:</dt>
-                        <dd class="{{ $dlValueClasses }}">{{ .Description }}</dd>
-                        {{ if .Dataset.PopulationType }}
-                            <dt class="{{ $dlTermClasses }}">{{ localise "PopulationTypes" $lang 1 }}:</dt>
-                            <dd class="{{ $dlValueClasses }}">{{ .Dataset.PopulationType }}</dd>
-                        {{ end }}
-                    </dl>
-                {{ end }}
             </li>
         {{end}}
     </ul>

--- a/assets/templates/time-series-tool.tmpl
+++ b/assets/templates/time-series-tool.tmpl
@@ -3,9 +3,9 @@
   <div class="ons-grid">
     <div class="ons-grid__col ons-col-12@m">
       <section class="search__summary">
-        <span class="search__summary__generic">
-          {{ localise "TimeSeriesExplorer" $lang 1 }}
-        </span>
+        <h1 class="ons-u-fs-xxxl">
+          {{- localise "TimeSeriesExplorer" $lang 1 -}}
+        </h1>
       </section>
     </div>
     <div class="ons-grid__col ons-col-4@m">

--- a/features/steps/component.go
+++ b/features/steps/component.go
@@ -176,10 +176,14 @@ func generateSearchItem(num int) searchModels.Item {
 
 	title := fmt.Sprintf("Test Bulletin %d", num)
 	uri := fmt.Sprintf("http://localhost://test-bulletin-%d", num)
+	cdid := fmt.Sprintf("AA%d", num)
+	datasetID := fmt.Sprintf("DD%d", num)
 
 	searchItem := searchModels.Item{
-		Title: title,
-		URI:   uri,
+		Title:     title,
+		URI:       uri,
+		CDID:      cdid,
+		DatasetID: datasetID,
 	}
 	return searchItem
 }

--- a/features/timeseries.feature
+++ b/features/timeseries.feature
@@ -1,0 +1,24 @@
+Feature: Timeseries Tool
+
+  Scenario: GET /timeseriestool and checking for zero results
+    Given there is a Search API that gives a successful response and returns 0 results
+    When I navigate to "/timeseriestool"
+    And the page should have the following content
+    """
+        {
+            "#main h1": "Time series explorer",
+            ".search__count h2": "0 results"
+        }
+    """
+  Scenario: GET /alladtimeseriestoolhocs and checking for one result
+    Given there is a Search API that gives a successful response and returns 1 results
+    When I navigate to "/timeseriestool"
+    And the page should have the following content
+    """
+        {
+            "#main h1": "Time series explorer",
+            ".search__count h2": "1 result",
+            ".ons-document-list__item-attribute:nth-child(2)": "Series ID: AA0",
+            ".ons-document-list__item-attribute:nth-child(3)": "Dataset ID: DD0"
+        }
+    """

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -317,6 +317,7 @@ func mapResponseItems(page *model.SearchPage, respC *searchModels.SearchResponse
 
 func mapItemDescription(item *model.ContentItem, itemC *searchModels.Item) {
 	item.Description = model.Description{
+		CDID:            itemC.CDID,
 		DatasetID:       itemC.DatasetID,
 		Language:        itemC.Language,
 		MetaDescription: itemC.MetaDescription,

--- a/model/search.go
+++ b/model/search.go
@@ -135,6 +135,7 @@ type Dataset struct {
 // Description represents each search result description
 type Description struct {
 	Contact           *Contact  `json:"contact,omitempty"`
+	CDID              string    `json:"cdid,omitempty"`
 	DatasetID         string    `json:"dataset_id,omitempty"`
 	Edition           string    `json:"edition,omitempty"`
 	Headline1         string    `json:"headline1,omitempty"`


### PR DESCRIPTION
### What

Added CDID and DatasetID to the timeseries explorer for parity with Babbage. They will appear on any aggregated page if there is a CDID / DatasetID mapped but I think that's ok?

Also hid the type on timeseries explorer (as they're always timeseries)

Also swapped the title for an H1 and removed redundant logic for datasetfinder

### How to review

Port forward to api router and run and see

### Who can review

Frontend Go Dev. 