### PR TITLE
WIP: Handle params in data aggregation routes

### DIFF
--- a/cache/caches.go
+++ b/cache/caches.go
@@ -3,5 +3,6 @@ package cache
 // CacheList is a list of caches for the dp-frontend-search-controller
 type List struct {
 	CensusTopic *TopicCache
+	DataTopic   *TopicCache
 	Navigation  *NavigationCache
 }

--- a/cache/topic.go
+++ b/cache/topic.go
@@ -95,6 +95,19 @@ func (dc *TopicCache) GetCensusData(ctx context.Context) (*Topic, error) {
 	return censusTopicCache, nil
 }
 
+func (dc *TopicCache) GetDataAggregationData(ctx context.Context) (*Topic, error) {
+	dataTopicCache, err := dc.GetData(ctx, CensusTopicID)
+	if err != nil {
+		logData := log.Data{
+			"key": CensusTopicID,
+		}
+		log.Error(ctx, "failed to get cached census topic data", err, logData)
+		return GetEmptyCensusTopic(), err
+	}
+
+	return dataTopicCache, nil
+}
+
 // GetEmptyCensusTopic returns an empty census topic cache in the event when updating the cache of the census topic fails
 func GetEmptyCensusTopic() *Topic {
 	return &Topic{

--- a/data/query.go
+++ b/data/query.go
@@ -155,6 +155,60 @@ func ReviewDataAggregationQuery(ctx context.Context, cfg *config.Config, urlQuer
 	return validatedQueryParams, queryStringErr
 }
 
+// ReviewDataAggregationQueryWithParams ensures that all search parameter values given by the user are reviewed
+func ReviewDataAggregationQueryWithParams(ctx context.Context, cfg *config.Config, urlQuery url.Values, censusTopicCache *cache.Topic) (SearchURLParams, error) {
+	var validatedQueryParams SearchURLParams
+	validatedQueryParams.Query = urlQuery.Get("q")
+
+	fromDate, toDate, err := GetDates(ctx, urlQuery)
+	if err != nil {
+		log.Error(ctx, "invalid dates set", err)
+		return validatedQueryParams, err
+	}
+	validatedQueryParams.AfterDate = fromDate
+	validatedQueryParams.BeforeDate = toDate
+
+	paginationErr := reviewPagination(ctx, cfg, urlQuery, &validatedQueryParams)
+	if paginationErr != nil {
+		log.Error(ctx, "unable to review pagination", paginationErr)
+		return validatedQueryParams, paginationErr
+	}
+
+	reviewSort(ctx, cfg, urlQuery, &validatedQueryParams)
+
+	contentTypeFilterError := reviewFilters(ctx, urlQuery, &validatedQueryParams)
+	if contentTypeFilterError != nil {
+		log.Error(ctx, "invalid content type filters set", contentTypeFilterError)
+		return validatedQueryParams, contentTypeFilterError
+	}
+	// TODO pass datatopiccache instead
+	topicFilterErr := reviewTopicFiltersForDataAggregation(ctx, urlQuery, &validatedQueryParams, censusTopicCache)
+	if topicFilterErr != nil {
+		log.Error(ctx, "invalid topic filters set", topicFilterErr)
+		return validatedQueryParams, topicFilterErr
+	}
+	populationTypeFilterErr := reviewPopulationTypeFilters(urlQuery, &validatedQueryParams)
+	if populationTypeFilterErr != nil {
+		log.Error(ctx, "invalid population types set", populationTypeFilterErr)
+		return validatedQueryParams, populationTypeFilterErr
+	}
+	dimensionsFilterErr := reviewDimensionsFilters(urlQuery, &validatedQueryParams)
+	if dimensionsFilterErr != nil {
+		log.Error(ctx, "invalid population types set", dimensionsFilterErr)
+		return validatedQueryParams, dimensionsFilterErr
+	}
+
+	queryStringErr := reviewQueryString(ctx, urlQuery)
+	if queryStringErr == nil {
+		return validatedQueryParams, nil
+	} else if errors.Is(queryStringErr, apperrors.ErrInvalidQueryCharLengthString) && hasFilters(validatedQueryParams) {
+		log.Info(ctx, "the query string did not pass review")
+		return validatedQueryParams, nil
+	}
+
+	return validatedQueryParams, queryStringErr
+}
+
 // ReviewQuery ensures that all search parameter values given by the user are reviewed
 func ReviewDatasetQuery(ctx context.Context, cfg *config.Config, urlQuery url.Values, censusTopicCache *cache.Topic) (SearchURLParams, error) {
 	var validatedQueryParams SearchURLParams

--- a/data/topic_filter.go
+++ b/data/topic_filter.go
@@ -123,6 +123,38 @@ func reviewTopicFilters(ctx context.Context, urlQuery url.Values, validatedQuery
 	return nil
 }
 
+// reviewTopicFiltersForDataAggregation retrieves subtopic ids from query, checks if they are one of the subtopics, and updates reviewTopicFiltersForDataAggregation
+func reviewTopicFiltersForDataAggregation(ctx context.Context, urlQuery url.Values, validatedQueryParams *SearchURLParams, censusTopicCache *cache.Topic) error {
+	topicFilters := urlQuery.Get("topics")
+	topicIDs := strings.Split(topicFilters, ",")
+
+	// log.Info(ctx, "this the topic ids", log.Data{"topics": topicIDs})
+
+	validatedTopicFilters := []string{}
+
+	for i := range topicIDs {
+		topicFilterQuery := strings.ToLower(topicIDs[i])
+
+		if topicFilterQuery == "" {
+			continue
+		}
+
+		// if ok := censusTopicCache.List.CheckTopicIDExists(topicFilterQuery); !ok {
+		// 	err := errs.ErrTopicNotFound
+		// 	logData := log.Data{"subtopic id not found": topicFilterQuery}
+		// 	log.Error(ctx, "failed to find subtopic id in census topic data", err, logData)
+		// 	return err
+		// }
+
+		validatedTopicFilters = append(validatedTopicFilters, topicIDs[i])
+		// log.Info(ctx, "this the validated topic filters", log.Data{"topics": validatedTopicFilters})
+	}
+
+	validatedQueryParams.TopicFilter = strings.Join(validatedTopicFilters, ",")
+
+	return nil
+}
+
 // updateTopicsQueryForSearchAPI updates the topics query with subtopic ids if one of the topic is a root id
 func updateTopicsQueryForSearchAPI(apiQuery url.Values, censusTopicCache *cache.Topic) {
 	topicFilters := apiQuery.Get("topics")

--- a/data/topic_filter.go
+++ b/data/topic_filter.go
@@ -128,8 +128,6 @@ func reviewTopicFiltersForDataAggregation(ctx context.Context, urlQuery url.Valu
 	topicFilters := urlQuery.Get("topics")
 	topicIDs := strings.Split(topicFilters, ",")
 
-	// log.Info(ctx, "this the topic ids", log.Data{"topics": topicIDs})
-
 	validatedTopicFilters := []string{}
 
 	for i := range topicIDs {
@@ -139,15 +137,7 @@ func reviewTopicFiltersForDataAggregation(ctx context.Context, urlQuery url.Valu
 			continue
 		}
 
-		// if ok := censusTopicCache.List.CheckTopicIDExists(topicFilterQuery); !ok {
-		// 	err := errs.ErrTopicNotFound
-		// 	logData := log.Data{"subtopic id not found": topicFilterQuery}
-		// 	log.Error(ctx, "failed to find subtopic id in census topic data", err, logData)
-		// 	return err
-		// }
-
 		validatedTopicFilters = append(validatedTopicFilters, topicIDs[i])
-		// log.Info(ctx, "this the validated topic filters", log.Data{"topics": validatedTopicFilters})
 	}
 
 	validatedQueryParams.TopicFilter = strings.Join(validatedTopicFilters, ",")

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -355,22 +355,7 @@ func readDataAggregationWithTopics(w http.ResponseWriter, req *http.Request, cfg
 		return
 	}
 
-	// log.Info(ctx, "this the root topics", log.Data{"topics": respRootTopics})
-
-	//TODO Loop through topics and compare with vars["topic"]
-	// get the topic to see if subtpic exists GetTopicPublic
-	// if vars["subTopic"] is defined search through the subtopics of the topic
-	// add topic to query and return matched data for topic/subtopic
-	// if topic or subtopic is invalid return defualt data
-
-	// clearTopics := false
-	// if urlQuery.Get("topics") == "" {
-	// 	urlQuery.Add("topics", censusTopicCache.Query)
-	// 	clearTopics = true
-	// }
-
 	rootTopicItems := *respRootTopics.PublicItems
-	// log.Info(ctx, "this the topic items", log.Data{"topics": rootTopicItems})
 	topics := []string{}
 	topLevelTopicID := ""
 
@@ -390,24 +375,16 @@ func readDataAggregationWithTopics(w http.ResponseWriter, req *http.Request, cfg
 		return
 	}
 
-	// log.Info(ctx, "this the subtopics", log.Data{"subtopics": subTopics})
-
-	// log.Info(ctx, "this the subtopic", log.Data{"subtopic": vars["subTopic"]})
-
 	rootSubTopicItems := *subTopics.PublicItems
 
-	//REMOVE SPACES FROM TITLE WHEN COMAPRING
 	for i := range rootSubTopicItems {
 		if strings.ReplaceAll(strings.ToLower(rootSubTopicItems[i].Title), " ", "") == strings.ToLower(vars["subTopic"]) {
-			// log.Info(ctx, "this the found subtopic", log.Data{"subtopics": rootSubTopicItems[i]})
 			topics = append(topics, rootSubTopicItems[i].ID)
 			break
 		}
 	}
 
 	defer cancel()
-
-	// log.Info(ctx, "this the topics to be applied to query", log.Data{"topicsids": strings.Join(topics, ",")})
 
 	urlQuery := req.URL.Query()
 

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -17,6 +17,7 @@ import (
 	dphandlers "github.com/ONSdigital/dp-net/v2/handlers"
 	searchModels "github.com/ONSdigital/dp-search-api/models"
 	searchSDK "github.com/ONSdigital/dp-search-api/sdk"
+	topic "github.com/ONSdigital/dp-topic-api/sdk"
 
 	"github.com/ONSdigital/log.go/v2/log"
 )
@@ -31,14 +32,16 @@ type HandlerClients struct {
 	Renderer      RenderClient
 	SearchClient  SearchClient
 	ZebedeeClient ZebedeeClient
+	TopicClient   *topic.Client
 }
 
 // NewHandlerClients creates a new instance of FilterFlex
-func NewHandlerClients(rc RenderClient, sc SearchClient, zc ZebedeeClient) *HandlerClients {
+func NewHandlerClients(rc RenderClient, sc SearchClient, zc ZebedeeClient, tc *topic.Client) *HandlerClients {
 	return &HandlerClients{
 		Renderer:      rc,
 		SearchClient:  sc,
 		ZebedeeClient: zc,
+		TopicClient:   tc,
 	}
 }
 
@@ -53,6 +56,12 @@ func Read(cfg *config.Config, hc *HandlerClients, cacheList cache.List, template
 	})
 
 	return cookies.Handler(cfg.ABTest.Enabled, newHandler, oldHandler, cfg.ABTest.Percentage, cfg.ABTest.AspectID, cfg.SiteDomain, cfg.ABTest.Exit)
+}
+
+func ReadDataAggregationWithTopics(cfg *config.Config, hc *HandlerClients, cacheList cache.List, template string) http.HandlerFunc {
+	return dphandlers.ControllerHandler(func(w http.ResponseWriter, req *http.Request, lang, collectionID, accessToken string) {
+		readDataAggregationWithTopics(w, req, cfg, hc.ZebedeeClient, hc.Renderer, hc.SearchClient, hc.TopicClient, accessToken, collectionID, lang, cacheList, template)
+	})
 }
 
 // Read Handler
@@ -324,6 +333,190 @@ func readDataAggregation(w http.ResponseWriter, req *http.Request, cfg *config.C
 	basePage := rend.NewBasePageModel()
 	m := mapper.CreateDataAggregationPage(cfg, req, basePage, validatedQueryParams, categories, topicCategories, populationTypes, dimensions, searchResp, lang, homepageResp, "", navigationCache, template)
 	// time-series-tool needs it's own template due to the need of elements to be present for JS to be able to assign onClick events(doesn't work if they're conditionally shown on the page)
+	if template != "time-series-tool" {
+		rend.BuildPage(w, m, "data-aggregation-page")
+	} else {
+		rend.BuildPage(w, m, template)
+	}
+}
+
+func readDataAggregationWithTopics(w http.ResponseWriter, req *http.Request, cfg *config.Config, zc ZebedeeClient, rend RenderClient, searchC SearchClient, topicC *topic.Client,
+	accessToken, collectionID, lang string, cacheList cache.List, template string,
+) {
+	ctx, cancel := context.WithCancel(req.Context())
+	vars := mux.Vars(req)
+
+	respRootTopics, errorrr := topicC.GetRootTopicsPublic(ctx, topic.Headers{})
+	if errorrr != nil {
+		logData := log.Data{
+			"req_headers": topic.Headers{},
+		}
+		log.Error(ctx, "failed to get root topics from topic-api", errorrr, logData)
+		return
+	}
+
+	// log.Info(ctx, "this the root topics", log.Data{"topics": respRootTopics})
+
+	//TODO Loop through topics and compare with vars["topic"]
+	// get the topic to see if subtpic exists GetTopicPublic
+	// if vars["subTopic"] is defined search through the subtopics of the topic
+	// add topic to query and return matched data for topic/subtopic
+	// if topic or subtopic is invalid return defualt data
+
+	// clearTopics := false
+	// if urlQuery.Get("topics") == "" {
+	// 	urlQuery.Add("topics", censusTopicCache.Query)
+	// 	clearTopics = true
+	// }
+
+	rootTopicItems := *respRootTopics.PublicItems
+	// log.Info(ctx, "this the topic items", log.Data{"topics": rootTopicItems})
+	topics := []string{}
+	topLevelTopicID := ""
+
+	for i := range rootTopicItems {
+		if strings.ReplaceAll(strings.ToLower(rootTopicItems[i].Title), " ", "") == strings.ToLower(vars["topic"]) {
+			log.Info(ctx, "this the found topic", log.Data{"topics": rootTopicItems[i]})
+			topics = append(topics, rootTopicItems[i].ID)
+			topLevelTopicID = rootTopicItems[i].ID
+			break
+		}
+	}
+
+	subTopics, errrrr := topicC.GetSubtopicsPublic(ctx, topic.Headers{}, topLevelTopicID)
+	if errrrr != nil {
+		log.Error(ctx, "failed to subtopics", errrrr)
+		setStatusCode(w, req, errrrr)
+		return
+	}
+
+	// log.Info(ctx, "this the subtopics", log.Data{"subtopics": subTopics})
+
+	// log.Info(ctx, "this the subtopic", log.Data{"subtopic": vars["subTopic"]})
+
+	rootSubTopicItems := *subTopics.PublicItems
+
+	//REMOVE SPACES FROM TITLE WHEN COMAPRING
+	for i := range rootSubTopicItems {
+		if strings.ReplaceAll(strings.ToLower(rootSubTopicItems[i].Title), " ", "") == strings.ToLower(vars["subTopic"]) {
+			// log.Info(ctx, "this the found subtopic", log.Data{"subtopics": rootSubTopicItems[i]})
+			topics = append(topics, rootSubTopicItems[i].ID)
+			break
+		}
+	}
+
+	defer cancel()
+
+	// log.Info(ctx, "this the topics to be applied to query", log.Data{"topicsids": strings.Join(topics, ",")})
+
+	urlQuery := req.URL.Query()
+
+	urlQuery.Add("topics", strings.Join(topics, ","))
+
+	// replace with new cache
+	censusTopicCache, err := cacheList.CensusTopic.GetCensusData(ctx)
+	if err != nil {
+		log.Error(ctx, "failed to get census topic cache", err)
+		setStatusCode(w, req, err)
+		return
+	}
+
+	log.Info(ctx, "this the census cache topics", log.Data{"topics": censusTopicCache})
+
+	// get cached navigation data
+	navigationCache, err := cacheList.Navigation.GetNavigationData(ctx, lang)
+	if err != nil {
+		log.Error(ctx, "failed to get navigation cache", err)
+		setStatusCode(w, req, err)
+		return
+	}
+
+	validatedQueryParams, err := data.ReviewDataAggregationQueryWithParams(ctx, cfg, urlQuery, censusTopicCache)
+	if err != nil && !errs.ErrMapForRenderBeforeAPICalls[err] {
+		log.Error(ctx, "unable to review query", err)
+		setStatusCode(w, req, err)
+		return
+	}
+
+	// counter used to keep track of the number of concurrent API calls
+	var counter = 3
+
+	searchQuery := data.GetDataAggregationQuery(validatedQueryParams, template)
+	categoriesCountQuery := getCategoriesCountQuery(searchQuery)
+
+	var (
+		homepageResp zebedeeCli.HomepageContent
+		searchResp   = &searchModels.SearchResponse{}
+
+		categories      []data.Category
+		topicCategories []data.Topic
+		populationTypes []data.PopulationTypes
+		dimensions      []data.Dimensions
+
+		wg sync.WaitGroup
+
+		respErr, countErr error
+	)
+	wg.Add(counter)
+
+	go func() {
+		defer wg.Done()
+		var homeErr error
+		homepageResp, homeErr = zc.GetHomepageContent(ctx, accessToken, collectionID, lang, homepagePath)
+		if homeErr != nil {
+			log.Warn(ctx, "unable to get homepage content", log.FormatErrors([]error{err}))
+			return
+		}
+	}()
+
+	var options searchSDK.Options
+
+	options.Query = searchQuery
+
+	options.Headers = http.Header{
+		searchSDK.FlorenceToken: {"Bearer " + accessToken},
+		searchSDK.CollectionID:  {collectionID},
+	}
+
+	go func() {
+		defer wg.Done()
+
+		searchResp, respErr = searchC.GetSearch(ctx, options)
+		if respErr != nil {
+			log.Error(ctx, "getting search response from client failed", respErr)
+			cancel()
+			return
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		// TO-DO: Need to make a second request until API can handle aggregration on datatypes (e.g. bulletins, article) to return counts
+		categories, topicCategories, countErr = getCategoriesTypesCount(ctx, accessToken, collectionID, categoriesCountQuery, searchC, censusTopicCache)
+		if countErr != nil {
+			log.Error(ctx, "getting categories, types and its counts failed", countErr)
+			setStatusCode(w, req, countErr)
+			cancel()
+			return
+		}
+	}()
+
+	wg.Wait()
+	if respErr != nil || countErr != nil {
+		setStatusCode(w, req, respErr)
+		return
+	}
+
+	err = validateCurrentPage(ctx, cfg, validatedQueryParams, searchResp.Count)
+	if err != nil {
+		log.Error(ctx, "unable to validate current page", err)
+		setStatusCode(w, req, err)
+		return
+	}
+	basePage := rend.NewBasePageModel()
+	m := mapper.CreateDataAggregationPage(cfg, req, basePage, validatedQueryParams, categories, topicCategories, populationTypes, dimensions, searchResp, lang, homepageResp, "", navigationCache, template)
+	//time-series-tool needs it's own template due to the need of elements to be present for JS to be able to assign onClick events(doesn't work if they're conditionally shown on the page)
 	if template != "time-series-tool" {
 		rend.BuildPage(w, m, "data-aggregation-page")
 	} else {

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -58,6 +58,7 @@ func Read(cfg *config.Config, hc *HandlerClients, cacheList cache.List, template
 	return cookies.Handler(cfg.ABTest.Enabled, newHandler, oldHandler, cfg.ABTest.Percentage, cfg.ABTest.AspectID, cfg.SiteDomain, cfg.ABTest.Exit)
 }
 
+//Read Handler for data aggregation routes with topic/subtopics
 func ReadDataAggregationWithTopics(cfg *config.Config, hc *HandlerClients, cacheList cache.List, template string) http.HandlerFunc {
 	return dphandlers.ControllerHandler(func(w http.ResponseWriter, req *http.Request, lang, collectionID, accessToken string) {
 		readDataAggregationWithTopics(w, req, cfg, hc.ZebedeeClient, hc.Renderer, hc.SearchClient, hc.TopicClient, accessToken, collectionID, lang, cacheList, template)
@@ -368,10 +369,10 @@ func readDataAggregationWithTopics(w http.ResponseWriter, req *http.Request, cfg
 		}
 	}
 
-	subTopics, errrrr := topicC.GetSubtopicsPublic(ctx, topic.Headers{}, topLevelTopicID)
-	if errrrr != nil {
-		log.Error(ctx, "failed to subtopics", errrrr)
-		setStatusCode(w, req, errrrr)
+	subTopics, err := topicC.GetSubtopicsPublic(ctx, topic.Headers{}, topLevelTopicID)
+	if err != nil {
+		log.Error(ctx, "failed to subtopics", err)
+		setStatusCode(w, req, err)
 		return
 	}
 

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -28,7 +28,7 @@ type Clients struct {
 func Setup(ctx context.Context, r *mux.Router, cfg *config.Config, c Clients, cacheList cache.List) {
 	log.Info(ctx, "adding routes")
 	r.StrictSlash(true).Path("/health").HandlerFunc(c.HealthCheckHandler)
-	hc := handlers.NewHandlerClients(c.Renderer, c.Search, c.Zebedee)
+	hc := handlers.NewHandlerClients(c.Renderer, c.Search, c.Zebedee, c.Topic)
 	r.StrictSlash(true).Path("/search").Methods("GET").HandlerFunc(handlers.Read(cfg, hc, cacheList, "search"))
 
 	if cfg.EnableReworkedDataAggregationPages {
@@ -40,6 +40,22 @@ func Setup(ctx context.Context, r *mux.Router, cfg *config.Config, c Clients, ca
 		r.StrictSlash(true).Path("/timeseriestool").Methods("GET").HandlerFunc(handlers.ReadDataAggregation(cfg, hc, cacheList, "time-series-tool"))
 		r.StrictSlash(true).Path("/publications").Methods("GET").HandlerFunc(handlers.ReadDataAggregation(cfg, hc, cacheList, "home-publications"))
 		r.StrictSlash(true).Path("/allmethodologies").Methods("GET").HandlerFunc(handlers.ReadDataAggregation(cfg, hc, cacheList, "all-methodologies"))
+
+		//datalist
+		r.StrictSlash(true).Path("/{topic}/datalist").Methods("GET").HandlerFunc(handlers.ReadDataAggregationWithTopics(cfg, hc, cacheList, "home-datalist"))
+		r.StrictSlash(true).Path("/{topic}/{subTopic}/datalist").Methods("GET").HandlerFunc(handlers.ReadDataAggregationWithTopics(cfg, hc, cacheList, "home-datalist"))
+
+		//publications
+		r.StrictSlash(true).Path("/{topic}/publications").Methods("GET").HandlerFunc(handlers.ReadDataAggregationWithTopics(cfg, hc, cacheList, "home-publications"))
+		r.StrictSlash(true).Path("/{topic}/{subTopic}/publications").Methods("GET").HandlerFunc(handlers.ReadDataAggregationWithTopics(cfg, hc, cacheList, "home-publications"))
+
+		//staticlist
+		r.StrictSlash(true).Path("/{topic}/staticlist").Methods("GET").HandlerFunc(handlers.ReadDataAggregationWithTopics(cfg, hc, cacheList, "home-list"))
+		r.StrictSlash(true).Path("/{topic}/{subTopic}/staticlist").Methods("GET").HandlerFunc(handlers.ReadDataAggregationWithTopics(cfg, hc, cacheList, "home-list"))
+
+		//topicspecificmethodology
+		r.StrictSlash(true).Path("/{topic}/topicspecificmethodology").Methods("GET").HandlerFunc(handlers.ReadDataAggregationWithTopics(cfg, hc, cacheList, "home-methodology"))
+		r.StrictSlash(true).Path("/{topic}/{subTopic}/topicspecificmethodology").Methods("GET").HandlerFunc(handlers.ReadDataAggregationWithTopics(cfg, hc, cacheList, "home-methodology"))
 	}
 
 	r.StrictSlash(true).Path("/census/find-a-dataset").Methods("GET").HandlerFunc(handlers.ReadFindDataset(cfg, hc, cacheList))


### PR DESCRIPTION
### What

Added handling for parameterized routes allowing using topic  and subtopic titles. This will allow accessing pages such as:
https://www.ons.gov.uk/economy/publications
https://www.ons.gov.uk/economy/grossdomesticproductgdp/publications
https://www.ons.gov.uk/businessindustryandtrade/publications
https://www.ons.gov.uk/businessindustryandtrade/business/publications
etc. 

This is a WIP. The feature itself works but it uses the Topic API for each check. A general topic cache must be created that gets used for these checks. I have added the first steps of creating it in the last commit. 

### How to review
Requires: https://github.com/ONSdigital/dp-frontend-router/pull/448

### Who can review
Anyone
