### PR TITLE
Feature/handle params in data aggregation routes

### DIFF
--- a/apperrors/errors.go
+++ b/apperrors/errors.go
@@ -12,6 +12,7 @@ var (
 	ErrInvalidQueryCharLengthString = errors.New("the query string is less than the required character length")
 	ErrPageExceedsTotalPages        = errors.New("invalid page value, exceeding the total page value")
 	ErrTopicNotFound                = errors.New("topic not found")
+	ErrTopicPathNotFound            = errors.New("topic path not found")
 
 	BadRequestMap = map[error]bool{
 		ErrContentTypeNotFound:   true,
@@ -19,6 +20,10 @@ var (
 		ErrInvalidQueryString:    true,
 		ErrPageExceedsTotalPages: true,
 		ErrTopicNotFound:         true,
+	}
+
+	NotFoundMap = map[error]bool{
+		ErrTopicPathNotFound: true,
 	}
 
 	// ErrMapForRenderBeforeAPICalls is a list of errors which leads to the search page being rendered before making any API calls

--- a/assets/templates/data-aggregation-page.tmpl
+++ b/assets/templates/data-aggregation-page.tmpl
@@ -5,7 +5,7 @@
     <div class="ons-grid__col ons-col-12@m">
       <section class="search__summary">
         <h1 class="ons-u-fs-xxxl">
-          {{- localise .Title.LocaliseKeyName $lang 1 }}
+          {{- localise .Title.LocaliseKeyName $lang 1 }}{{ if .Data.Topic }} related to {{ .Data.Topic -}}{{ end }}
         </h1>
       </section>
     </div>

--- a/cache/caches.go
+++ b/cache/caches.go
@@ -3,5 +3,6 @@ package cache
 // CacheList is a list of caches for the dp-frontend-search-controller
 type List struct {
 	CensusTopic *TopicCache
+	DataTopic   *TopicCache
 	Navigation  *NavigationCache
 }

--- a/cache/topic.go
+++ b/cache/topic.go
@@ -95,6 +95,19 @@ func (dc *TopicCache) GetCensusData(ctx context.Context) (*Topic, error) {
 	return censusTopicCache, nil
 }
 
+func (dc *TopicCache) GetDataAggregationData(ctx context.Context) (*Topic, error) {
+	dataTopicCache, err := dc.GetData(ctx, CensusTopicID)
+	if err != nil {
+		logData := log.Data{
+			"key": CensusTopicID,
+		}
+		log.Error(ctx, "failed to get cached census topic data", err, logData)
+		return GetEmptyCensusTopic(), err
+	}
+
+	return dataTopicCache, nil
+}
+
 // GetEmptyCensusTopic returns an empty census topic cache in the event when updating the cache of the census topic fails
 func GetEmptyCensusTopic() *Topic {
 	return &Topic{

--- a/data/query.go
+++ b/data/query.go
@@ -174,7 +174,7 @@ func ReviewDataAggregationQueryWithParams(ctx context.Context, cfg *config.Confi
 		return validatedQueryParams, paginationErr
 	}
 
-	reviewSort(ctx, cfg, urlQuery, &validatedQueryParams)
+	reviewSort(ctx, urlQuery, &validatedQueryParams, cfg.DefaultAggregationSort)
 
 	contentTypeFilterError := reviewFilters(ctx, urlQuery, &validatedQueryParams)
 	if contentTypeFilterError != nil {

--- a/data/query.go
+++ b/data/query.go
@@ -155,6 +155,60 @@ func ReviewDataAggregationQuery(ctx context.Context, cfg *config.Config, urlQuer
 	return validatedQueryParams, queryStringErr
 }
 
+// ReviewDataAggregationQueryWithParams ensures that all search parameter values given by the user are reviewed
+func ReviewDataAggregationQueryWithParams(ctx context.Context, cfg *config.Config, urlQuery url.Values, censusTopicCache *cache.Topic) (SearchURLParams, error) {
+	var validatedQueryParams SearchURLParams
+	validatedQueryParams.Query = urlQuery.Get("q")
+
+	fromDate, toDate, err := GetDates(ctx, urlQuery)
+	if err != nil {
+		log.Error(ctx, "invalid dates set", err)
+		return validatedQueryParams, err
+	}
+	validatedQueryParams.AfterDate = fromDate
+	validatedQueryParams.BeforeDate = toDate
+
+	paginationErr := reviewPagination(ctx, cfg, urlQuery, &validatedQueryParams)
+	if paginationErr != nil {
+		log.Error(ctx, "unable to review pagination", paginationErr)
+		return validatedQueryParams, paginationErr
+	}
+
+	reviewSort(ctx, cfg, urlQuery, &validatedQueryParams)
+
+	contentTypeFilterError := reviewFilters(ctx, urlQuery, &validatedQueryParams)
+	if contentTypeFilterError != nil {
+		log.Error(ctx, "invalid content type filters set", contentTypeFilterError)
+		return validatedQueryParams, contentTypeFilterError
+	}
+	// TODO pass datatopiccache instead
+	topicFilterErr := reviewTopicFiltersForDataAggregation(ctx, urlQuery, &validatedQueryParams, censusTopicCache)
+	if topicFilterErr != nil {
+		log.Error(ctx, "invalid topic filters set", topicFilterErr)
+		return validatedQueryParams, topicFilterErr
+	}
+	populationTypeFilterErr := reviewPopulationTypeFilters(urlQuery, &validatedQueryParams)
+	if populationTypeFilterErr != nil {
+		log.Error(ctx, "invalid population types set", populationTypeFilterErr)
+		return validatedQueryParams, populationTypeFilterErr
+	}
+	dimensionsFilterErr := reviewDimensionsFilters(urlQuery, &validatedQueryParams)
+	if dimensionsFilterErr != nil {
+		log.Error(ctx, "invalid population types set", dimensionsFilterErr)
+		return validatedQueryParams, dimensionsFilterErr
+	}
+
+	queryStringErr := reviewQueryString(ctx, urlQuery)
+	if queryStringErr == nil {
+		return validatedQueryParams, nil
+	} else if errors.Is(queryStringErr, apperrors.ErrInvalidQueryCharLengthString) && hasFilters(validatedQueryParams) {
+		log.Info(ctx, "the query string did not pass review")
+		return validatedQueryParams, nil
+	}
+
+	return validatedQueryParams, queryStringErr
+}
+
 // ReviewQuery ensures that all search parameter values given by the user are reviewed
 func ReviewDatasetQuery(ctx context.Context, cfg *config.Config, urlQuery url.Values, censusTopicCache *cache.Topic) (SearchURLParams, error) {
 	var validatedQueryParams SearchURLParams

--- a/data/topic_filter.go
+++ b/data/topic_filter.go
@@ -123,6 +123,38 @@ func reviewTopicFilters(ctx context.Context, urlQuery url.Values, validatedQuery
 	return nil
 }
 
+// reviewTopicFiltersForDataAggregation retrieves subtopic ids from query, checks if they are one of the subtopics, and updates reviewTopicFiltersForDataAggregation
+func reviewTopicFiltersForDataAggregation(ctx context.Context, urlQuery url.Values, validatedQueryParams *SearchURLParams, censusTopicCache *cache.Topic) error {
+	topicFilters := urlQuery.Get("topics")
+	topicIDs := strings.Split(topicFilters, ",")
+
+	// log.Info(ctx, "this the topic ids", log.Data{"topics": topicIDs})
+
+	validatedTopicFilters := []string{}
+
+	for i := range topicIDs {
+		topicFilterQuery := strings.ToLower(topicIDs[i])
+
+		if topicFilterQuery == "" {
+			continue
+		}
+
+		// if ok := censusTopicCache.List.CheckTopicIDExists(topicFilterQuery); !ok {
+		// 	err := errs.ErrTopicNotFound
+		// 	logData := log.Data{"subtopic id not found": topicFilterQuery}
+		// 	log.Error(ctx, "failed to find subtopic id in census topic data", err, logData)
+		// 	return err
+		// }
+
+		validatedTopicFilters = append(validatedTopicFilters, topicIDs[i])
+		// log.Info(ctx, "this the validated topic filters", log.Data{"topics": validatedTopicFilters})
+	}
+
+	validatedQueryParams.TopicFilter = strings.Join(validatedTopicFilters, ",")
+
+	return nil
+}
+
 // updateTopicsQueryForSearchAPI updates the topics query with subtopic ids if one of the topic is a root id
 func updateTopicsQueryForSearchAPI(apiQuery url.Values, censusTopicCache *cache.Topic) {
 	topicFilters := apiQuery.Get("topics")

--- a/data/topic_filter.go
+++ b/data/topic_filter.go
@@ -128,8 +128,6 @@ func reviewTopicFiltersForDataAggregation(ctx context.Context, urlQuery url.Valu
 	topicFilters := urlQuery.Get("topics")
 	topicIDs := strings.Split(topicFilters, ",")
 
-	// log.Info(ctx, "this the topic ids", log.Data{"topics": topicIDs})
-
 	validatedTopicFilters := []string{}
 
 	for i := range topicIDs {
@@ -139,15 +137,7 @@ func reviewTopicFiltersForDataAggregation(ctx context.Context, urlQuery url.Valu
 			continue
 		}
 
-		// if ok := censusTopicCache.List.CheckTopicIDExists(topicFilterQuery); !ok {
-		// 	err := errs.ErrTopicNotFound
-		// 	logData := log.Data{"subtopic id not found": topicFilterQuery}
-		// 	log.Error(ctx, "failed to find subtopic id in census topic data", err, logData)
-		// 	return err
-		// }
-
 		validatedTopicFilters = append(validatedTopicFilters, topicIDs[i])
-		// log.Info(ctx, "this the validated topic filters", log.Data{"topics": validatedTopicFilters})
 	}
 
 	validatedQueryParams.TopicFilter = strings.Join(validatedTopicFilters, ",")

--- a/features/aggregation.feature
+++ b/features/aggregation.feature
@@ -59,3 +59,49 @@ Feature: Aggregated Data Pages
     Given there is a Search API that gives a successful response and returns 10 results
     When I navigate to "/alladhocs?sort=relevance"
     Then input element "#sort" has value "relevance"
+
+  Scenario: GET topic pre-filtered page with matching topic
+    Given there is a Search API that gives a successful response and returns 10 results
+    And there is a Topic API that returns the "economy" root topic
+    When I navigate to "/economy/publications"
+    Then the page should have the following content
+    """
+        {
+            "#main h1": "Publications related to economy",
+            ".search__count h2": "10 results"
+        }
+    """
+
+  Scenario: GET topic pre-filtered page with non-matching topic
+    Given there is a Search API that gives a successful response and returns 10 results
+    And there is a Topic API returns no topics
+    When I navigate to "/testpath/publications"
+    Then the page should have the following content
+    """
+        {
+            "#main h1": "Page not found"
+        }
+    """
+
+  Scenario: GET subtopic pre-filtered page with matching topic
+    Given there is a Search API that gives a successful response and returns 10 results
+    And there is a Topic API that returns the "economy" root topic and the "environmental" subtopic
+    When I navigate to "/economy/environmental/publications"
+    Then the page should have the following content
+    """
+        {
+            "#main h1": "Publications related to environmental",
+            ".search__count h2": "10 results"
+        }
+    """
+
+  Scenario: GET subtopic pre-filtered page with non-matching topic
+    Given there is a Search API that gives a successful response and returns 10 results
+    And there is a Topic API that returns the "economy" root topic and the "environmental" subtopic
+    When I navigate to "/economy/testtopic/publications"
+    Then the page should have the following content
+    """
+        {
+            "#main h1": "Page not found"
+        }
+    """

--- a/features/aggregation.feature
+++ b/features/aggregation.feature
@@ -2,6 +2,7 @@ Feature: Aggregated Data Pages
 
   Scenario: GET /alladhocs and checking for zero results
     Given there is a Search API that gives a successful response and returns 0 results
+    And the search controller is running
     When I navigate to "/alladhocs"
     And the page should have the following content
       """
@@ -13,12 +14,14 @@ Feature: Aggregated Data Pages
 
   Scenario: GET /alladhocs and date fieldsets are displayed
     Given there is a Search API that gives a successful response and returns 0 results
+    And the search controller is running
     When I navigate to "/alladhocs"
     Then element "#to-date-filters" should be visible
     Then element "#from-date-filters" should be visible
 
   Scenario: GET /alladhocs and checking for one result
     Given there is a Search API that gives a successful response and returns 1 results
+    And the search controller is running
     When I navigate to "/alladhocs"
     And the page should have the following content
       """
@@ -30,6 +33,7 @@ Feature: Aggregated Data Pages
       """
   Scenario: GET /alladhocs and checking for 10 results
     Given there is a Search API that gives a successful response and returns 10 results
+    And the search controller is running
     When I navigate to "/alladhocs"
     And the page should have the following content
       """
@@ -41,6 +45,7 @@ Feature: Aggregated Data Pages
       """
   Scenario: GET /alladhocs and checking for 11 results
     Given there is a Search API that gives a successful response and returns 11 results
+    And the search controller is running
     When I navigate to "/alladhocs"
     And the page should have the following content
       """
@@ -52,17 +57,20 @@ Feature: Aggregated Data Pages
       """
   Scenario: GET /alladhocs and check default sort
     Given there is a Search API that gives a successful response and returns 10 results
+    And the search controller is running
     When I navigate to "/alladhocs"
     Then input element "#sort" has value "release_date"
 
   Scenario: GET /alladhocs and check param driven sort
     Given there is a Search API that gives a successful response and returns 10 results
+    And the search controller is running
     When I navigate to "/alladhocs?sort=relevance"
     Then input element "#sort" has value "relevance"
 
   Scenario: GET topic pre-filtered page with matching topic
     Given there is a Search API that gives a successful response and returns 10 results
     And there is a Topic API that returns the "economy" root topic
+    And the search controller is running
     When I navigate to "/economy/publications"
     Then the page should have the following content
     """
@@ -75,6 +83,7 @@ Feature: Aggregated Data Pages
   Scenario: GET topic pre-filtered page with non-matching topic
     Given there is a Search API that gives a successful response and returns 10 results
     And there is a Topic API returns no topics
+    And the search controller is running
     When I navigate to "/testpath/publications"
     Then the page should have the following content
     """
@@ -86,6 +95,7 @@ Feature: Aggregated Data Pages
   Scenario: GET subtopic pre-filtered page with matching topic
     Given there is a Search API that gives a successful response and returns 10 results
     And there is a Topic API that returns the "economy" root topic and the "environmental" subtopic
+    And the search controller is running
     When I navigate to "/economy/environmental/publications"
     Then the page should have the following content
     """
@@ -98,6 +108,7 @@ Feature: Aggregated Data Pages
   Scenario: GET subtopic pre-filtered page with non-matching topic
     Given there is a Search API that gives a successful response and returns 10 results
     And there is a Topic API that returns the "economy" root topic and the "environmental" subtopic
+    And the search controller is running
     When I navigate to "/economy/testtopic/publications"
     Then the page should have the following content
     """

--- a/features/healthcheck.feature
+++ b/features/healthcheck.feature
@@ -1,7 +1,8 @@
 Feature: Healthcheck endpoint should inform the health of service
 
     Scenario: Returning a OK (200) status when health endpoint called  
-        Given all of the downstream services are healthy
+        Given the search controller is running
+        And all of the downstream services are healthy
         And I wait 2 seconds for the healthcheck to be available
         When I GET "/health"
         Then the HTTP status code should be "200"
@@ -27,8 +28,9 @@ Feature: Healthcheck endpoint should inform the health of service
             }
         """
 
-    Scenario: Returning a WARNING (429) status when one downstream service is warning  
-        Given one of the downstream services is warning
+    Scenario: Returning a WARNING (429) status when one downstream service is warning
+        Given the search controller is running  
+        And one of the downstream services is warning
         And I wait 2 seconds for the healthcheck to be available
         When I GET "/health"
         Then the HTTP status code should be "429"
@@ -55,7 +57,8 @@ Feature: Healthcheck endpoint should inform the health of service
         """
 
     Scenario: Returning a WARNING (429) status when one downstream service is critical and critical timeout has not expired  
-        Given one of the downstream services is failing
+        Given the search controller is running
+        And one of the downstream services is failing
         And I wait 2 seconds for the healthcheck to be available
         When I GET "/health"
         Then the HTTP status code should be "429"
@@ -82,7 +85,8 @@ Feature: Healthcheck endpoint should inform the health of service
         """
 
     Scenario: Returning a CRITICAL (500) status when health endpoint called
-        Given one of the downstream services is failing
+        Given the search controller is running
+        And one of the downstream services is failing
         And I wait 2 seconds for the healthcheck to be available
         When I GET "/health"
         And I wait 4 seconds to pass the critical timeout

--- a/features/search.feature
+++ b/features/search.feature
@@ -1,6 +1,7 @@
 Feature: Search
   Scenario: GET /search and checking for zero results
     Given there is a Search API that gives a successful response and returns 0 results
+    And the search controller is running
     When I navigate to "/search?q=test+query"
     And the page should have the following content
     """
@@ -11,6 +12,7 @@ Feature: Search
     """
   Scenario: GET /search and checking for one result
     Given there is a Search API that gives a successful response and returns 1 results
+    And the search controller is running
     When I navigate to "/search?q=test+query"
     And the page should have the following content
     """
@@ -23,6 +25,7 @@ Feature: Search
 
   Scenario: GET /search and checking for 10 results
     Given there is a Search API that gives a successful response and returns 10 results
+    And the search controller is running
     When I navigate to "/search?q=test+query"
     And the page should have the following content
     """
@@ -34,6 +37,7 @@ Feature: Search
     """
   Scenario: GET /search and checking for 11 results
     Given there is a Search API that gives a successful response and returns 11 results
+    And the search controller is running
     When I navigate to "/search?q=test+query"
     And the page should have the following content
     """
@@ -44,6 +48,7 @@ Feature: Search
         }
     """
   Scenario: GET /search with no query
+    Given the search controller is running
     When I navigate to "/search"
     And the page should have the following content
     """

--- a/features/steps/component.go
+++ b/features/steps/component.go
@@ -71,6 +71,7 @@ func NewSearchControllerComponent() (c *Component, err error) {
 	c.FakeAPIRouter.searchRequest.Response = generateSearchResponse(1)
 
 	c.FakeAPIRouter.topicRequest = c.FakeAPIRouter.fakeHTTP.NewHandler().Get("/topics")
+	c.FakeAPIRouter.subtopicsRequest = c.FakeAPIRouter.fakeHTTP.NewHandler().Get("/topics/*/subtopics")
 
 	c.FakeAPIRouter.navigationRequest = c.FakeAPIRouter.fakeHTTP.NewHandler().Get("/data")
 

--- a/features/steps/component.go
+++ b/features/steps/component.go
@@ -48,8 +48,6 @@ func NewSearchControllerComponent() (c *Component, err error) {
 
 	ctx := context.Background()
 
-	svcErrors := make(chan error, 1)
-
 	c.Config, err = config.Get()
 	if err != nil {
 		return nil, err
@@ -70,7 +68,6 @@ func NewSearchControllerComponent() (c *Component, err error) {
 
 	c.FakeAPIRouter.searchRequest = c.FakeAPIRouter.fakeHTTP.NewHandler().Get("/search")
 	c.FakeAPIRouter.searchRequest.Response = generateSearchResponse(1)
-
 	c.FakeAPIRouter.topicRequest = c.FakeAPIRouter.fakeHTTP.NewHandler().Get("/topics")
 	c.FakeAPIRouter.subtopicsRequest = c.FakeAPIRouter.fakeHTTP.NewHandler().Get("/topics/*/subtopics")
 
@@ -90,10 +87,9 @@ func NewSearchControllerComponent() (c *Component, err error) {
 		return nil, err
 	}
 
-	c.StartTime = time.Now()
-	c.svc.Run(ctx, svcErrors)
-	c.ServiceRunning = true
-
+	// Please use the step to start the service - this is down to
+	// the auto updates against backing services are hard to predict so
+	// it is easier to provision them first and then start the service.
 	return c, nil
 }
 

--- a/features/steps/component.go
+++ b/features/steps/component.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 	dphttp "github.com/ONSdigital/dp-net/v2/http"
 	searchModels "github.com/ONSdigital/dp-search-api/models"
+	topicModels "github.com/ONSdigital/dp-topic-api/models"
 	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/maxcnunes/httpfake"
 )
@@ -187,4 +188,35 @@ func generateSearchItem(num int) searchModels.Item {
 		DatasetID: datasetID,
 	}
 	return searchItem
+}
+
+func generateTopicResponse(id string, title string) *httpfake.Response {
+	topicAPIResponse := &topicModels.PublicSubtopics{
+		Count: 1,
+		PublicItems: &[]topicModels.Topic{
+			{
+				ID:    id,
+				Title: title,
+			},
+		},
+	}
+
+	fakeAPIResponse := httpfake.NewResponse()
+	fakeAPIResponse.Status(200)
+	fakeAPIResponse.BodyStruct(topicAPIResponse)
+
+	return fakeAPIResponse
+}
+
+func generateEmptyTopicResponse() *httpfake.Response {
+	topicAPIResponse := &topicModels.PublicSubtopics{
+		Count:       0,
+		PublicItems: &[]topicModels.Topic{},
+	}
+
+	fakeAPIResponse := httpfake.NewResponse()
+	fakeAPIResponse.Status(200)
+	fakeAPIResponse.BodyStruct(topicAPIResponse)
+
+	return fakeAPIResponse
 }

--- a/features/steps/fakeapi.go
+++ b/features/steps/fakeapi.go
@@ -10,6 +10,7 @@ type FakeAPI struct {
 	healthRequest                *httpfake.Request
 	searchRequest                *httpfake.Request
 	topicRequest                 *httpfake.Request
+	subtopicsRequest             *httpfake.Request
 	navigationRequest            *httpfake.Request
 	outboundRequests             []string
 	collectOutboundRequestBodies httpfake.CustomAssertor

--- a/features/timeseries.feature
+++ b/features/timeseries.feature
@@ -2,6 +2,7 @@ Feature: Timeseries Tool
 
   Scenario: GET /timeseriestool and checking for zero results
     Given there is a Search API that gives a successful response and returns 0 results
+    And the search controller is running
     When I navigate to "/timeseriestool"
     And the page should have the following content
     """
@@ -12,12 +13,14 @@ Feature: Timeseries Tool
     """
   Scenario: GET /timeseriestool and checking for date fieldsets
     Given there is a Search API that gives a successful response and returns 0 results
+    And the search controller is running
     When I navigate to "/timeseriestool"
     Then element "#to-date-filters" should be visible
     Then element "#from-date-filters" should be visible
 
   Scenario: GET /timeseriestool and checking for one result
     Given there is a Search API that gives a successful response and returns 1 results
+    And the search controller is running
     When I navigate to "/timeseriestool"
     And the page should have the following content
     """

--- a/handlers/clients.go
+++ b/handlers/clients.go
@@ -6,13 +6,17 @@ import (
 
 	searchModels "github.com/ONSdigital/dp-search-api/models"
 	searchSDK "github.com/ONSdigital/dp-search-api/sdk"
-	apiError "github.com/ONSdigital/dp-search-api/sdk/errors"
+	searchError "github.com/ONSdigital/dp-search-api/sdk/errors"
+
+	topicModels "github.com/ONSdigital/dp-topic-api/models"
+	topicSDK "github.com/ONSdigital/dp-topic-api/sdk"
+	topicError "github.com/ONSdigital/dp-topic-api/sdk/errors"
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/zebedee"
 	coreModel "github.com/ONSdigital/dp-renderer/v2/model"
 )
 
-//go:generate moq -out clients_mock.go -pkg handlers . RenderClient SearchClient ZebedeeClient
+//go:generate moq -out clients_mock.go -pkg handlers . RenderClient SearchClient ZebedeeClient TopicClient
 
 // ClientError is an interface that can be used to retrieve the status code if a client has errored
 type ClientError interface {
@@ -32,10 +36,21 @@ type RenderClient interface {
 
 // SearchClient is an interface with methods required for a search client
 type SearchClient interface {
-	GetSearch(ctx context.Context, options searchSDK.Options) (*searchModels.SearchResponse, apiError.Error)
+	GetSearch(ctx context.Context, options searchSDK.Options) (*searchModels.SearchResponse, searchError.Error)
 }
 
 // ZebedeeClient is an interface with methods required for a zebedee client
 type ZebedeeClient interface {
 	GetHomepageContent(ctx context.Context, userAuthToken, collectionID, lang, path string) (m zebedee.HomepageContent, err error)
+}
+
+// TopicClient is an interface with methods required for a zebedee client
+type TopicClient interface {
+	GetNavigationPublic(ctx context.Context, reqHeaders topicSDK.Headers, options topicSDK.Options) (*topicModels.Navigation, topicError.Error)
+	GetRootTopicsPrivate(ctx context.Context, reqHeaders topicSDK.Headers) (*topicModels.PrivateSubtopics, topicError.Error)
+	GetRootTopicsPublic(ctx context.Context, reqHeaders topicSDK.Headers) (*topicModels.PublicSubtopics, topicError.Error)
+	GetSubtopicsPrivate(ctx context.Context, reqHeaders topicSDK.Headers, id string) (*topicModels.PrivateSubtopics, topicError.Error)
+	GetSubtopicsPublic(ctx context.Context, reqHeaders topicSDK.Headers, id string) (*topicModels.PublicSubtopics, topicError.Error)
+	GetTopicPrivate(ctx context.Context, reqHeaders topicSDK.Headers, id string) (*topicModels.TopicResponse, topicError.Error)
+	GetTopicPublic(ctx context.Context, reqHeaders topicSDK.Headers, id string) (*topicModels.Topic, topicError.Error)
 }

--- a/handlers/clients_mock.go
+++ b/handlers/clients_mock.go
@@ -5,87 +5,17 @@ package handlers
 
 import (
 	"context"
-	"io"
-	"sync"
-
 	zebedeeCli "github.com/ONSdigital/dp-api-clients-go/v2/zebedee"
 	coreModel "github.com/ONSdigital/dp-renderer/v2/model"
 	searchModels "github.com/ONSdigital/dp-search-api/models"
 	searchSDK "github.com/ONSdigital/dp-search-api/sdk"
 	apiError "github.com/ONSdigital/dp-search-api/sdk/errors"
+	topicModels "github.com/ONSdigital/dp-topic-api/models"
+	topic "github.com/ONSdigital/dp-topic-api/sdk"
+	topicError "github.com/ONSdigital/dp-topic-api/sdk/errors"
+	"io"
+	"sync"
 )
-
-// Ensure, that SearchClientMock does implement SearchClient.
-// If this is not the case, regenerate this file with moq.
-var _ SearchClient = &SearchClientMock{}
-
-// SearchClientMock is a mock implementation of SearchClient.
-//
-//	func TestSomethingThatUsesSearchClient(t *testing.T) {
-//
-//		// make and configure a mocked SearchClient
-//		mockedSearchClient := &SearchClientMock{
-//			GetSearchFunc: func(ctx context.Context, options searchSDK.Options) (*searchModels.SearchResponse, apiError.Error) {
-//				panic("mock out the GetSearch method")
-//			},
-//		}
-//
-//		// use mockedSearchClient in code that requires SearchClient
-//		// and then make assertions.
-//
-//	}
-type SearchClientMock struct {
-	// GetSearchFunc mocks the GetSearch method.
-	GetSearchFunc func(ctx context.Context, options searchSDK.Options) (*searchModels.SearchResponse, apiError.Error)
-
-	// calls tracks calls to the methods.
-	calls struct {
-		// GetSearch holds details about calls to the GetSearch method.
-		GetSearch []struct {
-			// Ctx is the ctx argument value.
-			Ctx context.Context
-			// Options is the options argument value.
-			Options searchSDK.Options
-		}
-	}
-	lockGetSearch sync.RWMutex
-}
-
-// GetSearch calls GetSearchFunc.
-func (mock *SearchClientMock) GetSearch(ctx context.Context, options searchSDK.Options) (*searchModels.SearchResponse, apiError.Error) {
-	if mock.GetSearchFunc == nil {
-		panic("SearchClientMock.GetSearchFunc: method is nil but SearchClient.GetSearch was just called")
-	}
-	callInfo := struct {
-		Ctx     context.Context
-		Options searchSDK.Options
-	}{
-		Ctx:     ctx,
-		Options: options,
-	}
-	mock.lockGetSearch.Lock()
-	mock.calls.GetSearch = append(mock.calls.GetSearch, callInfo)
-	mock.lockGetSearch.Unlock()
-	return mock.GetSearchFunc(ctx, options)
-}
-
-// GetSearchCalls gets all the calls that were made to GetSearch.
-// Check the length with:
-//
-//	len(mockedSearchClient.GetSearchCalls())
-func (mock *SearchClientMock) GetSearchCalls() []struct {
-	Ctx     context.Context
-	Options searchSDK.Options
-} {
-	var calls []struct {
-		Ctx     context.Context
-		Options searchSDK.Options
-	}
-	mock.lockGetSearch.RLock()
-	calls = mock.calls.GetSearch
-	mock.lockGetSearch.RUnlock()
-	return calls
-}
 
 // Ensure, that RenderClientMock does implement RenderClient.
 // If this is not the case, regenerate this file with moq.
@@ -202,6 +132,78 @@ func (mock *RenderClientMock) NewBasePageModelCalls() []struct {
 	return calls
 }
 
+// Ensure, that SearchClientMock does implement SearchClient.
+// If this is not the case, regenerate this file with moq.
+var _ SearchClient = &SearchClientMock{}
+
+// SearchClientMock is a mock implementation of SearchClient.
+//
+//	func TestSomethingThatUsesSearchClient(t *testing.T) {
+//
+//		// make and configure a mocked SearchClient
+//		mockedSearchClient := &SearchClientMock{
+//			GetSearchFunc: func(ctx context.Context, options searchSDK.Options) (*searchModels.SearchResponse, apiError.Error) {
+//				panic("mock out the GetSearch method")
+//			},
+//		}
+//
+//		// use mockedSearchClient in code that requires SearchClient
+//		// and then make assertions.
+//
+//	}
+type SearchClientMock struct {
+	// GetSearchFunc mocks the GetSearch method.
+	GetSearchFunc func(ctx context.Context, options searchSDK.Options) (*searchModels.SearchResponse, apiError.Error)
+
+	// calls tracks calls to the methods.
+	calls struct {
+		// GetSearch holds details about calls to the GetSearch method.
+		GetSearch []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Options is the options argument value.
+			Options searchSDK.Options
+		}
+	}
+	lockGetSearch sync.RWMutex
+}
+
+// GetSearch calls GetSearchFunc.
+func (mock *SearchClientMock) GetSearch(ctx context.Context, options searchSDK.Options) (*searchModels.SearchResponse, apiError.Error) {
+	if mock.GetSearchFunc == nil {
+		panic("SearchClientMock.GetSearchFunc: method is nil but SearchClient.GetSearch was just called")
+	}
+	callInfo := struct {
+		Ctx     context.Context
+		Options searchSDK.Options
+	}{
+		Ctx:     ctx,
+		Options: options,
+	}
+	mock.lockGetSearch.Lock()
+	mock.calls.GetSearch = append(mock.calls.GetSearch, callInfo)
+	mock.lockGetSearch.Unlock()
+	return mock.GetSearchFunc(ctx, options)
+}
+
+// GetSearchCalls gets all the calls that were made to GetSearch.
+// Check the length with:
+//
+//	len(mockedSearchClient.GetSearchCalls())
+func (mock *SearchClientMock) GetSearchCalls() []struct {
+	Ctx     context.Context
+	Options searchSDK.Options
+} {
+	var calls []struct {
+		Ctx     context.Context
+		Options searchSDK.Options
+	}
+	mock.lockGetSearch.RLock()
+	calls = mock.calls.GetSearch
+	mock.lockGetSearch.RUnlock()
+	return calls
+}
+
 // Ensure, that ZebedeeClientMock does implement ZebedeeClient.
 // If this is not the case, regenerate this file with moq.
 var _ ZebedeeClient = &ZebedeeClientMock{}
@@ -289,5 +291,469 @@ func (mock *ZebedeeClientMock) GetHomepageContentCalls() []struct {
 	mock.lockGetHomepageContent.RLock()
 	calls = mock.calls.GetHomepageContent
 	mock.lockGetHomepageContent.RUnlock()
+	return calls
+}
+
+// Ensure, that TopicClientMock does implement TopicClient.
+// If this is not the case, regenerate this file with moq.
+var _ TopicClient = &TopicClientMock{}
+
+// TopicClientMock is a mock implementation of TopicClient.
+//
+//	func TestSomethingThatUsesTopicClient(t *testing.T) {
+//
+//		// make and configure a mocked TopicClient
+//		mockedTopicClient := &TopicClientMock{
+//			GetNavigationPublicFunc: func(ctx context.Context, reqHeaders topic.Headers, options topic.Options) (*topicModels.Navigation, topicError.Error) {
+//				panic("mock out the GetNavigationPublic method")
+//			},
+//			GetRootTopicsPrivateFunc: func(ctx context.Context, reqHeaders topic.Headers) (*topicModels.PrivateSubtopics, topicError.Error) {
+//				panic("mock out the GetRootTopicsPrivate method")
+//			},
+//			GetRootTopicsPublicFunc: func(ctx context.Context, reqHeaders topic.Headers) (*topicModels.PublicSubtopics, topicError.Error) {
+//				panic("mock out the GetRootTopicsPublic method")
+//			},
+//			GetSubtopicsPrivateFunc: func(ctx context.Context, reqHeaders topic.Headers, id string) (*topicModels.PrivateSubtopics, topicError.Error) {
+//				panic("mock out the GetSubtopicsPrivate method")
+//			},
+//			GetSubtopicsPublicFunc: func(ctx context.Context, reqHeaders topic.Headers, id string) (*topicModels.PublicSubtopics, topicError.Error) {
+//				panic("mock out the GetSubtopicsPublic method")
+//			},
+//			GetTopicPrivateFunc: func(ctx context.Context, reqHeaders topic.Headers, id string) (*topicModels.TopicResponse, topicError.Error) {
+//				panic("mock out the GetTopicPrivate method")
+//			},
+//			GetTopicPublicFunc: func(ctx context.Context, reqHeaders topic.Headers, id string) (*topicModels.Topic, topicError.Error) {
+//				panic("mock out the GetTopicPublic method")
+//			},
+//			PutTopicReleasePrivateFunc: func(ctx context.Context, reqHeaders topic.Headers, id string, topicRelease []byte) (*topic.ResponseInfo, topicError.Error) {
+//				panic("mock out the PutTopicReleasePrivate method")
+//			},
+//		}
+//
+//		// use mockedTopicClient in code that requires TopicClient
+//		// and then make assertions.
+//
+//	}
+type TopicClientMock struct {
+	// GetNavigationPublicFunc mocks the GetNavigationPublic method.
+	GetNavigationPublicFunc func(ctx context.Context, reqHeaders topic.Headers, options topic.Options) (*topicModels.Navigation, topicError.Error)
+
+	// GetRootTopicsPrivateFunc mocks the GetRootTopicsPrivate method.
+	GetRootTopicsPrivateFunc func(ctx context.Context, reqHeaders topic.Headers) (*topicModels.PrivateSubtopics, topicError.Error)
+
+	// GetRootTopicsPublicFunc mocks the GetRootTopicsPublic method.
+	GetRootTopicsPublicFunc func(ctx context.Context, reqHeaders topic.Headers) (*topicModels.PublicSubtopics, topicError.Error)
+
+	// GetSubtopicsPrivateFunc mocks the GetSubtopicsPrivate method.
+	GetSubtopicsPrivateFunc func(ctx context.Context, reqHeaders topic.Headers, id string) (*topicModels.PrivateSubtopics, topicError.Error)
+
+	// GetSubtopicsPublicFunc mocks the GetSubtopicsPublic method.
+	GetSubtopicsPublicFunc func(ctx context.Context, reqHeaders topic.Headers, id string) (*topicModels.PublicSubtopics, topicError.Error)
+
+	// GetTopicPrivateFunc mocks the GetTopicPrivate method.
+	GetTopicPrivateFunc func(ctx context.Context, reqHeaders topic.Headers, id string) (*topicModels.TopicResponse, topicError.Error)
+
+	// GetTopicPublicFunc mocks the GetTopicPublic method.
+	GetTopicPublicFunc func(ctx context.Context, reqHeaders topic.Headers, id string) (*topicModels.Topic, topicError.Error)
+
+	// PutTopicReleasePrivateFunc mocks the PutTopicReleasePrivate method.
+	PutTopicReleasePrivateFunc func(ctx context.Context, reqHeaders topic.Headers, id string, topicRelease []byte) (*topic.ResponseInfo, topicError.Error)
+
+	// calls tracks calls to the methods.
+	calls struct {
+		// GetNavigationPublic holds details about calls to the GetNavigationPublic method.
+		GetNavigationPublic []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// ReqHeaders is the reqHeaders argument value.
+			ReqHeaders topic.Headers
+			// Options is the options argument value.
+			Options topic.Options
+		}
+		// GetRootTopicsPrivate holds details about calls to the GetRootTopicsPrivate method.
+		GetRootTopicsPrivate []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// ReqHeaders is the reqHeaders argument value.
+			ReqHeaders topic.Headers
+		}
+		// GetRootTopicsPublic holds details about calls to the GetRootTopicsPublic method.
+		GetRootTopicsPublic []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// ReqHeaders is the reqHeaders argument value.
+			ReqHeaders topic.Headers
+		}
+		// GetSubtopicsPrivate holds details about calls to the GetSubtopicsPrivate method.
+		GetSubtopicsPrivate []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// ReqHeaders is the reqHeaders argument value.
+			ReqHeaders topic.Headers
+			// ID is the id argument value.
+			ID string
+		}
+		// GetSubtopicsPublic holds details about calls to the GetSubtopicsPublic method.
+		GetSubtopicsPublic []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// ReqHeaders is the reqHeaders argument value.
+			ReqHeaders topic.Headers
+			// ID is the id argument value.
+			ID string
+		}
+		// GetTopicPrivate holds details about calls to the GetTopicPrivate method.
+		GetTopicPrivate []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// ReqHeaders is the reqHeaders argument value.
+			ReqHeaders topic.Headers
+			// ID is the id argument value.
+			ID string
+		}
+		// GetTopicPublic holds details about calls to the GetTopicPublic method.
+		GetTopicPublic []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// ReqHeaders is the reqHeaders argument value.
+			ReqHeaders topic.Headers
+			// ID is the id argument value.
+			ID string
+		}
+		// PutTopicReleasePrivate holds details about calls to the PutTopicReleasePrivate method.
+		PutTopicReleasePrivate []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// ReqHeaders is the reqHeaders argument value.
+			ReqHeaders topic.Headers
+			// ID is the id argument value.
+			ID string
+			// TopicRelease is the topicRelease argument value.
+			TopicRelease []byte
+		}
+	}
+	lockGetNavigationPublic    sync.RWMutex
+	lockGetRootTopicsPrivate   sync.RWMutex
+	lockGetRootTopicsPublic    sync.RWMutex
+	lockGetSubtopicsPrivate    sync.RWMutex
+	lockGetSubtopicsPublic     sync.RWMutex
+	lockGetTopicPrivate        sync.RWMutex
+	lockGetTopicPublic         sync.RWMutex
+	lockPutTopicReleasePrivate sync.RWMutex
+}
+
+// GetNavigationPublic calls GetNavigationPublicFunc.
+func (mock *TopicClientMock) GetNavigationPublic(ctx context.Context, reqHeaders topic.Headers, options topic.Options) (*topicModels.Navigation, topicError.Error) {
+	if mock.GetNavigationPublicFunc == nil {
+		panic("TopicClientMock.GetNavigationPublicFunc: method is nil but TopicClient.GetNavigationPublic was just called")
+	}
+	callInfo := struct {
+		Ctx        context.Context
+		ReqHeaders topic.Headers
+		Options    topic.Options
+	}{
+		Ctx:        ctx,
+		ReqHeaders: reqHeaders,
+		Options:    options,
+	}
+	mock.lockGetNavigationPublic.Lock()
+	mock.calls.GetNavigationPublic = append(mock.calls.GetNavigationPublic, callInfo)
+	mock.lockGetNavigationPublic.Unlock()
+	return mock.GetNavigationPublicFunc(ctx, reqHeaders, options)
+}
+
+// GetNavigationPublicCalls gets all the calls that were made to GetNavigationPublic.
+// Check the length with:
+//
+//	len(mockedTopicClient.GetNavigationPublicCalls())
+func (mock *TopicClientMock) GetNavigationPublicCalls() []struct {
+	Ctx        context.Context
+	ReqHeaders topic.Headers
+	Options    topic.Options
+} {
+	var calls []struct {
+		Ctx        context.Context
+		ReqHeaders topic.Headers
+		Options    topic.Options
+	}
+	mock.lockGetNavigationPublic.RLock()
+	calls = mock.calls.GetNavigationPublic
+	mock.lockGetNavigationPublic.RUnlock()
+	return calls
+}
+
+// GetRootTopicsPrivate calls GetRootTopicsPrivateFunc.
+func (mock *TopicClientMock) GetRootTopicsPrivate(ctx context.Context, reqHeaders topic.Headers) (*topicModels.PrivateSubtopics, topicError.Error) {
+	if mock.GetRootTopicsPrivateFunc == nil {
+		panic("TopicClientMock.GetRootTopicsPrivateFunc: method is nil but TopicClient.GetRootTopicsPrivate was just called")
+	}
+	callInfo := struct {
+		Ctx        context.Context
+		ReqHeaders topic.Headers
+	}{
+		Ctx:        ctx,
+		ReqHeaders: reqHeaders,
+	}
+	mock.lockGetRootTopicsPrivate.Lock()
+	mock.calls.GetRootTopicsPrivate = append(mock.calls.GetRootTopicsPrivate, callInfo)
+	mock.lockGetRootTopicsPrivate.Unlock()
+	return mock.GetRootTopicsPrivateFunc(ctx, reqHeaders)
+}
+
+// GetRootTopicsPrivateCalls gets all the calls that were made to GetRootTopicsPrivate.
+// Check the length with:
+//
+//	len(mockedTopicClient.GetRootTopicsPrivateCalls())
+func (mock *TopicClientMock) GetRootTopicsPrivateCalls() []struct {
+	Ctx        context.Context
+	ReqHeaders topic.Headers
+} {
+	var calls []struct {
+		Ctx        context.Context
+		ReqHeaders topic.Headers
+	}
+	mock.lockGetRootTopicsPrivate.RLock()
+	calls = mock.calls.GetRootTopicsPrivate
+	mock.lockGetRootTopicsPrivate.RUnlock()
+	return calls
+}
+
+// GetRootTopicsPublic calls GetRootTopicsPublicFunc.
+func (mock *TopicClientMock) GetRootTopicsPublic(ctx context.Context, reqHeaders topic.Headers) (*topicModels.PublicSubtopics, topicError.Error) {
+	if mock.GetRootTopicsPublicFunc == nil {
+		panic("TopicClientMock.GetRootTopicsPublicFunc: method is nil but TopicClient.GetRootTopicsPublic was just called")
+	}
+	callInfo := struct {
+		Ctx        context.Context
+		ReqHeaders topic.Headers
+	}{
+		Ctx:        ctx,
+		ReqHeaders: reqHeaders,
+	}
+	mock.lockGetRootTopicsPublic.Lock()
+	mock.calls.GetRootTopicsPublic = append(mock.calls.GetRootTopicsPublic, callInfo)
+	mock.lockGetRootTopicsPublic.Unlock()
+	return mock.GetRootTopicsPublicFunc(ctx, reqHeaders)
+}
+
+// GetRootTopicsPublicCalls gets all the calls that were made to GetRootTopicsPublic.
+// Check the length with:
+//
+//	len(mockedTopicClient.GetRootTopicsPublicCalls())
+func (mock *TopicClientMock) GetRootTopicsPublicCalls() []struct {
+	Ctx        context.Context
+	ReqHeaders topic.Headers
+} {
+	var calls []struct {
+		Ctx        context.Context
+		ReqHeaders topic.Headers
+	}
+	mock.lockGetRootTopicsPublic.RLock()
+	calls = mock.calls.GetRootTopicsPublic
+	mock.lockGetRootTopicsPublic.RUnlock()
+	return calls
+}
+
+// GetSubtopicsPrivate calls GetSubtopicsPrivateFunc.
+func (mock *TopicClientMock) GetSubtopicsPrivate(ctx context.Context, reqHeaders topic.Headers, id string) (*topicModels.PrivateSubtopics, topicError.Error) {
+	if mock.GetSubtopicsPrivateFunc == nil {
+		panic("TopicClientMock.GetSubtopicsPrivateFunc: method is nil but TopicClient.GetSubtopicsPrivate was just called")
+	}
+	callInfo := struct {
+		Ctx        context.Context
+		ReqHeaders topic.Headers
+		ID         string
+	}{
+		Ctx:        ctx,
+		ReqHeaders: reqHeaders,
+		ID:         id,
+	}
+	mock.lockGetSubtopicsPrivate.Lock()
+	mock.calls.GetSubtopicsPrivate = append(mock.calls.GetSubtopicsPrivate, callInfo)
+	mock.lockGetSubtopicsPrivate.Unlock()
+	return mock.GetSubtopicsPrivateFunc(ctx, reqHeaders, id)
+}
+
+// GetSubtopicsPrivateCalls gets all the calls that were made to GetSubtopicsPrivate.
+// Check the length with:
+//
+//	len(mockedTopicClient.GetSubtopicsPrivateCalls())
+func (mock *TopicClientMock) GetSubtopicsPrivateCalls() []struct {
+	Ctx        context.Context
+	ReqHeaders topic.Headers
+	ID         string
+} {
+	var calls []struct {
+		Ctx        context.Context
+		ReqHeaders topic.Headers
+		ID         string
+	}
+	mock.lockGetSubtopicsPrivate.RLock()
+	calls = mock.calls.GetSubtopicsPrivate
+	mock.lockGetSubtopicsPrivate.RUnlock()
+	return calls
+}
+
+// GetSubtopicsPublic calls GetSubtopicsPublicFunc.
+func (mock *TopicClientMock) GetSubtopicsPublic(ctx context.Context, reqHeaders topic.Headers, id string) (*topicModels.PublicSubtopics, topicError.Error) {
+	if mock.GetSubtopicsPublicFunc == nil {
+		panic("TopicClientMock.GetSubtopicsPublicFunc: method is nil but TopicClient.GetSubtopicsPublic was just called")
+	}
+	callInfo := struct {
+		Ctx        context.Context
+		ReqHeaders topic.Headers
+		ID         string
+	}{
+		Ctx:        ctx,
+		ReqHeaders: reqHeaders,
+		ID:         id,
+	}
+	mock.lockGetSubtopicsPublic.Lock()
+	mock.calls.GetSubtopicsPublic = append(mock.calls.GetSubtopicsPublic, callInfo)
+	mock.lockGetSubtopicsPublic.Unlock()
+	return mock.GetSubtopicsPublicFunc(ctx, reqHeaders, id)
+}
+
+// GetSubtopicsPublicCalls gets all the calls that were made to GetSubtopicsPublic.
+// Check the length with:
+//
+//	len(mockedTopicClient.GetSubtopicsPublicCalls())
+func (mock *TopicClientMock) GetSubtopicsPublicCalls() []struct {
+	Ctx        context.Context
+	ReqHeaders topic.Headers
+	ID         string
+} {
+	var calls []struct {
+		Ctx        context.Context
+		ReqHeaders topic.Headers
+		ID         string
+	}
+	mock.lockGetSubtopicsPublic.RLock()
+	calls = mock.calls.GetSubtopicsPublic
+	mock.lockGetSubtopicsPublic.RUnlock()
+	return calls
+}
+
+// GetTopicPrivate calls GetTopicPrivateFunc.
+func (mock *TopicClientMock) GetTopicPrivate(ctx context.Context, reqHeaders topic.Headers, id string) (*topicModels.TopicResponse, topicError.Error) {
+	if mock.GetTopicPrivateFunc == nil {
+		panic("TopicClientMock.GetTopicPrivateFunc: method is nil but TopicClient.GetTopicPrivate was just called")
+	}
+	callInfo := struct {
+		Ctx        context.Context
+		ReqHeaders topic.Headers
+		ID         string
+	}{
+		Ctx:        ctx,
+		ReqHeaders: reqHeaders,
+		ID:         id,
+	}
+	mock.lockGetTopicPrivate.Lock()
+	mock.calls.GetTopicPrivate = append(mock.calls.GetTopicPrivate, callInfo)
+	mock.lockGetTopicPrivate.Unlock()
+	return mock.GetTopicPrivateFunc(ctx, reqHeaders, id)
+}
+
+// GetTopicPrivateCalls gets all the calls that were made to GetTopicPrivate.
+// Check the length with:
+//
+//	len(mockedTopicClient.GetTopicPrivateCalls())
+func (mock *TopicClientMock) GetTopicPrivateCalls() []struct {
+	Ctx        context.Context
+	ReqHeaders topic.Headers
+	ID         string
+} {
+	var calls []struct {
+		Ctx        context.Context
+		ReqHeaders topic.Headers
+		ID         string
+	}
+	mock.lockGetTopicPrivate.RLock()
+	calls = mock.calls.GetTopicPrivate
+	mock.lockGetTopicPrivate.RUnlock()
+	return calls
+}
+
+// GetTopicPublic calls GetTopicPublicFunc.
+func (mock *TopicClientMock) GetTopicPublic(ctx context.Context, reqHeaders topic.Headers, id string) (*topicModels.Topic, topicError.Error) {
+	if mock.GetTopicPublicFunc == nil {
+		panic("TopicClientMock.GetTopicPublicFunc: method is nil but TopicClient.GetTopicPublic was just called")
+	}
+	callInfo := struct {
+		Ctx        context.Context
+		ReqHeaders topic.Headers
+		ID         string
+	}{
+		Ctx:        ctx,
+		ReqHeaders: reqHeaders,
+		ID:         id,
+	}
+	mock.lockGetTopicPublic.Lock()
+	mock.calls.GetTopicPublic = append(mock.calls.GetTopicPublic, callInfo)
+	mock.lockGetTopicPublic.Unlock()
+	return mock.GetTopicPublicFunc(ctx, reqHeaders, id)
+}
+
+// GetTopicPublicCalls gets all the calls that were made to GetTopicPublic.
+// Check the length with:
+//
+//	len(mockedTopicClient.GetTopicPublicCalls())
+func (mock *TopicClientMock) GetTopicPublicCalls() []struct {
+	Ctx        context.Context
+	ReqHeaders topic.Headers
+	ID         string
+} {
+	var calls []struct {
+		Ctx        context.Context
+		ReqHeaders topic.Headers
+		ID         string
+	}
+	mock.lockGetTopicPublic.RLock()
+	calls = mock.calls.GetTopicPublic
+	mock.lockGetTopicPublic.RUnlock()
+	return calls
+}
+
+// PutTopicReleasePrivate calls PutTopicReleasePrivateFunc.
+func (mock *TopicClientMock) PutTopicReleasePrivate(ctx context.Context, reqHeaders topic.Headers, id string, topicRelease []byte) (*topic.ResponseInfo, topicError.Error) {
+	if mock.PutTopicReleasePrivateFunc == nil {
+		panic("TopicClientMock.PutTopicReleasePrivateFunc: method is nil but TopicClient.PutTopicReleasePrivate was just called")
+	}
+	callInfo := struct {
+		Ctx          context.Context
+		ReqHeaders   topic.Headers
+		ID           string
+		TopicRelease []byte
+	}{
+		Ctx:          ctx,
+		ReqHeaders:   reqHeaders,
+		ID:           id,
+		TopicRelease: topicRelease,
+	}
+	mock.lockPutTopicReleasePrivate.Lock()
+	mock.calls.PutTopicReleasePrivate = append(mock.calls.PutTopicReleasePrivate, callInfo)
+	mock.lockPutTopicReleasePrivate.Unlock()
+	return mock.PutTopicReleasePrivateFunc(ctx, reqHeaders, id, topicRelease)
+}
+
+// PutTopicReleasePrivateCalls gets all the calls that were made to PutTopicReleasePrivate.
+// Check the length with:
+//
+//	len(mockedTopicClient.PutTopicReleasePrivateCalls())
+func (mock *TopicClientMock) PutTopicReleasePrivateCalls() []struct {
+	Ctx          context.Context
+	ReqHeaders   topic.Headers
+	ID           string
+	TopicRelease []byte
+} {
+	var calls []struct {
+		Ctx          context.Context
+		ReqHeaders   topic.Headers
+		ID           string
+		TopicRelease []byte
+	}
+	mock.lockPutTopicReleasePrivate.RLock()
+	calls = mock.calls.PutTopicReleasePrivate
+	mock.lockPutTopicReleasePrivate.RUnlock()
 	return calls
 }

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -884,8 +883,6 @@ func getTopicByURLString(topicURLString string, topics []topicModels.Topic) (top
 	nonAlphanumericRegex := regexp.MustCompile(`[^a-zA-Z0-9]+`)
 
 	for _, topic := range topics {
-		fmt.Println(nonAlphanumericRegex.ReplaceAllString(strings.ToLower(topic.Title), ""))
-
 		if nonAlphanumericRegex.ReplaceAllString(strings.ToLower(topic.Title), "") == strings.ToLower(topicURLString) {
 			return topic, nil
 		}

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -61,6 +61,7 @@ func Read(cfg *config.Config, hc *HandlerClients, cacheList cache.List, template
 	return cookies.Handler(cfg.ABTest.Enabled, newHandler, oldHandler, cfg.ABTest.Percentage, cfg.ABTest.AspectID, cfg.SiteDomain, cfg.ABTest.Exit)
 }
 
+//Read Handler for data aggregation routes with topic/subtopics
 func ReadDataAggregationWithTopics(cfg *config.Config, hc *HandlerClients, cacheList cache.List, template string) http.HandlerFunc {
 	return dphandlers.ControllerHandler(func(w http.ResponseWriter, req *http.Request, lang, collectionID, accessToken string) {
 		readDataAggregationWithTopics(w, req, cfg, hc.ZebedeeClient, hc.Renderer, hc.SearchClient, hc.TopicClient, accessToken, collectionID, lang, cacheList, template)
@@ -380,10 +381,10 @@ func readDataAggregationWithTopics(w http.ResponseWriter, req *http.Request, cfg
 		}
 	}
 
-	subTopics, errrrr := topicC.GetSubtopicsPublic(ctx, topic.Headers{}, topLevelTopicID)
-	if errrrr != nil {
-		log.Error(ctx, "failed to subtopics", errrrr)
-		setStatusCode(w, req, errrrr)
+	subTopics, err := topicC.GetSubtopicsPublic(ctx, topic.Headers{}, topLevelTopicID)
+	if err != nil {
+		log.Error(ctx, "failed to subtopics", err)
+		setStatusCode(w, req, err)
 		return
 	}
 

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -13,7 +13,6 @@ import (
 	zebedeeCli "github.com/ONSdigital/dp-api-clients-go/v2/zebedee"
 	"github.com/ONSdigital/dp-cookies/cookies"
 	"github.com/ONSdigital/dp-frontend-search-controller/apperrors"
-	errs "github.com/ONSdigital/dp-frontend-search-controller/apperrors"
 	"github.com/ONSdigital/dp-frontend-search-controller/cache"
 	"github.com/ONSdigital/dp-frontend-search-controller/config"
 	"github.com/ONSdigital/dp-frontend-search-controller/data"
@@ -120,7 +119,7 @@ func readFindDataset(w http.ResponseWriter, req *http.Request, cfg *config.Confi
 	}
 
 	validatedQueryParams, err := data.ReviewDatasetQuery(ctx, cfg, urlQuery, censusTopicCache)
-	if err != nil && !errs.ErrMapForRenderBeforeAPICalls[err] {
+	if err != nil && !apperrors.ErrMapForRenderBeforeAPICalls[err] {
 		log.Error(ctx, "unable to review query", err)
 		setStatusCode(w, req, err)
 		return
@@ -134,7 +133,7 @@ func readFindDataset(w http.ResponseWriter, req *http.Request, cfg *config.Confi
 	)
 
 	// avoid making unecessary search API calls
-	if errs.ErrMapForRenderBeforeAPICalls[err] {
+	if apperrors.ErrMapForRenderBeforeAPICalls[err] {
 		makeSearchAPICalls = false
 
 		// reduce counter by the number of concurrent search API calls that would be
@@ -257,7 +256,7 @@ func readDataAggregation(w http.ResponseWriter, req *http.Request, cfg *config.C
 	}
 
 	validatedQueryParams, err := data.ReviewDataAggregationQuery(ctx, cfg, urlQuery, censusTopicCache)
-	if err != nil && !errs.ErrMapForRenderBeforeAPICalls[err] {
+	if err != nil && !apperrors.ErrMapForRenderBeforeAPICalls[err] {
 		log.Error(ctx, "unable to review query", err)
 		setStatusCode(w, req, err)
 		return
@@ -436,7 +435,7 @@ func readDataAggregationWithTopics(w http.ResponseWriter, req *http.Request, cfg
 	}
 
 	validatedQueryParams, err := data.ReviewDataAggregationQueryWithParams(ctx, cfg, urlQuery, censusTopicCache)
-	if err != nil && !errs.ErrMapForRenderBeforeAPICalls[err] {
+	if err != nil && !apperrors.ErrMapForRenderBeforeAPICalls[err] {
 		log.Error(ctx, "unable to review query", err)
 		setStatusCode(w, req, err)
 		return
@@ -553,7 +552,7 @@ func read(w http.ResponseWriter, req *http.Request, cfg *config.Config, zc Zebed
 	}
 
 	validatedQueryParams, err := data.ReviewQuery(ctx, cfg, urlQuery, censusTopicCache)
-	if err != nil && !errs.ErrMapForRenderBeforeAPICalls[err] {
+	if err != nil && !apperrors.ErrMapForRenderBeforeAPICalls[err] {
 		log.Error(ctx, "unable to review query", err)
 		setStatusCode(w, req, err)
 		return
@@ -572,7 +571,7 @@ func read(w http.ResponseWriter, req *http.Request, cfg *config.Config, zc Zebed
 	)
 
 	// avoid making unecessary search API calls
-	if errs.ErrMapForRenderBeforeAPICalls[err] {
+	if apperrors.ErrMapForRenderBeforeAPICalls[err] {
 		makeSearchAPICalls = false
 
 		// reduce counter by the number of concurrent search API calls that would be
@@ -664,7 +663,7 @@ func validateCurrentPage(ctx context.Context, cfg *config.Config, validatedQuery
 		totalPages := data.GetTotalPages(cfg, validatedQueryParams.Limit, resultsCount)
 
 		if validatedQueryParams.CurrentPage > totalPages {
-			err := errs.ErrPageExceedsTotalPages
+			err := apperrors.ErrPageExceedsTotalPages
 			log.Error(ctx, "current page exceeds total pages", err)
 
 			return err
@@ -772,11 +771,11 @@ func setStatusCode(w http.ResponseWriter, req *http.Request, err error) {
 		}
 	}
 
-	if errs.BadRequestMap[err] {
+	if apperrors.BadRequestMap[err] {
 		status = http.StatusBadRequest
 	}
 
-	if errs.NotFoundMap[err] {
+	if apperrors.NotFoundMap[err] {
 		status = http.StatusNotFound
 	}
 

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -876,6 +877,8 @@ func getPageTitle(template string) (pageTitle, pageTag string) {
 	}
 
 	return "", ""
+}
+
 // getTopicByURLString matches a URL string, e.g. businessindustryandtrade against
 // a Topic retrieved from the Topic API, using it's Title attribute, e.g.
 // "Business, industry and trade"

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -283,8 +283,6 @@ func readDataAggregation(w http.ResponseWriter, req *http.Request, cfg *config.C
 
 		categories      []data.Category
 		topicCategories []data.Topic
-		populationTypes []data.PopulationTypes
-		dimensions      []data.Dimensions
 
 		wg sync.WaitGroup
 
@@ -348,7 +346,7 @@ func readDataAggregation(w http.ResponseWriter, req *http.Request, cfg *config.C
 		return
 	}
 	basePage := rend.NewBasePageModel()
-	m := mapper.CreateDataAggregationPage(cfg, req, basePage, validatedQueryParams, categories, topicCategories, populationTypes, dimensions, searchResp, lang, homepageResp, "", navigationCache, template, topicModels.Topic{})
+	m := mapper.CreateDataAggregationPage(cfg, req, basePage, validatedQueryParams, categories, topicCategories, searchResp, lang, homepageResp, "", navigationCache, template, topicModels.Topic{})
 	// time-series-tool needs it's own template due to the need of elements to be present for JS to be able to assign onClick events(doesn't work if they're conditionally shown on the page)
 	if template != "time-series-tool" {
 		rend.BuildPage(w, m, "data-aggregation-page")
@@ -453,8 +451,6 @@ func readDataAggregationWithTopics(w http.ResponseWriter, req *http.Request, cfg
 
 		categories      []data.Category
 		topicCategories []data.Topic
-		populationTypes []data.PopulationTypes
-		dimensions      []data.Dimensions
 
 		wg sync.WaitGroup
 
@@ -518,7 +514,7 @@ func readDataAggregationWithTopics(w http.ResponseWriter, req *http.Request, cfg
 		return
 	}
 	basePage := rend.NewBasePageModel()
-	m := mapper.CreateDataAggregationPage(cfg, req, basePage, validatedQueryParams, categories, topicCategories, populationTypes, dimensions, searchResp, lang, homepageResp, "", navigationCache, template, selectedTopic)
+	m := mapper.CreateDataAggregationPage(cfg, req, basePage, validatedQueryParams, categories, topicCategories, searchResp, lang, homepageResp, "", navigationCache, template, selectedTopic)
 	// time-series-tool needs it's own template due to the need of elements to be present for JS to be able to assign onClick events(doesn't work if they're conditionally shown on the page)
 	if template != "time-series-tool" {
 		rend.BuildPage(w, m, "data-aggregation-page")

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -19,6 +19,8 @@ import (
 	dphandlers "github.com/ONSdigital/dp-net/v2/handlers"
 	searchModels "github.com/ONSdigital/dp-search-api/models"
 	searchSDK "github.com/ONSdigital/dp-search-api/sdk"
+	topic "github.com/ONSdigital/dp-topic-api/sdk"
+
 	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/gorilla/feeds"
 )
@@ -33,14 +35,16 @@ type HandlerClients struct {
 	Renderer      RenderClient
 	SearchClient  SearchClient
 	ZebedeeClient ZebedeeClient
+	TopicClient   *topic.Client
 }
 
 // NewHandlerClients creates a new instance of FilterFlex
-func NewHandlerClients(rc RenderClient, sc SearchClient, zc ZebedeeClient) *HandlerClients {
+func NewHandlerClients(rc RenderClient, sc SearchClient, zc ZebedeeClient, tc *topic.Client) *HandlerClients {
 	return &HandlerClients{
 		Renderer:      rc,
 		SearchClient:  sc,
 		ZebedeeClient: zc,
+		TopicClient:   tc,
 	}
 }
 
@@ -55,6 +59,12 @@ func Read(cfg *config.Config, hc *HandlerClients, cacheList cache.List, template
 	})
 
 	return cookies.Handler(cfg.ABTest.Enabled, newHandler, oldHandler, cfg.ABTest.Percentage, cfg.ABTest.AspectID, cfg.SiteDomain, cfg.ABTest.Exit)
+}
+
+func ReadDataAggregationWithTopics(cfg *config.Config, hc *HandlerClients, cacheList cache.List, template string) http.HandlerFunc {
+	return dphandlers.ControllerHandler(func(w http.ResponseWriter, req *http.Request, lang, collectionID, accessToken string) {
+		readDataAggregationWithTopics(w, req, cfg, hc.ZebedeeClient, hc.Renderer, hc.SearchClient, hc.TopicClient, accessToken, collectionID, lang, cacheList, template)
+	})
 }
 
 // Read Handler
@@ -335,6 +345,190 @@ func readDataAggregation(w http.ResponseWriter, req *http.Request, cfg *config.C
 	basePage := rend.NewBasePageModel()
 	m := mapper.CreateDataAggregationPage(cfg, req, basePage, validatedQueryParams, categories, topicCategories, populationTypes, dimensions, searchResp, lang, homepageResp, "", navigationCache, template)
 	// time-series-tool needs it's own template due to the need of elements to be present for JS to be able to assign onClick events(doesn't work if they're conditionally shown on the page)
+	if template != "time-series-tool" {
+		rend.BuildPage(w, m, "data-aggregation-page")
+	} else {
+		rend.BuildPage(w, m, template)
+	}
+}
+
+func readDataAggregationWithTopics(w http.ResponseWriter, req *http.Request, cfg *config.Config, zc ZebedeeClient, rend RenderClient, searchC SearchClient, topicC *topic.Client,
+	accessToken, collectionID, lang string, cacheList cache.List, template string,
+) {
+	ctx, cancel := context.WithCancel(req.Context())
+	vars := mux.Vars(req)
+
+	respRootTopics, errorrr := topicC.GetRootTopicsPublic(ctx, topic.Headers{})
+	if errorrr != nil {
+		logData := log.Data{
+			"req_headers": topic.Headers{},
+		}
+		log.Error(ctx, "failed to get root topics from topic-api", errorrr, logData)
+		return
+	}
+
+	// log.Info(ctx, "this the root topics", log.Data{"topics": respRootTopics})
+
+	//TODO Loop through topics and compare with vars["topic"]
+	// get the topic to see if subtpic exists GetTopicPublic
+	// if vars["subTopic"] is defined search through the subtopics of the topic
+	// add topic to query and return matched data for topic/subtopic
+	// if topic or subtopic is invalid return defualt data
+
+	// clearTopics := false
+	// if urlQuery.Get("topics") == "" {
+	// 	urlQuery.Add("topics", censusTopicCache.Query)
+	// 	clearTopics = true
+	// }
+
+	rootTopicItems := *respRootTopics.PublicItems
+	// log.Info(ctx, "this the topic items", log.Data{"topics": rootTopicItems})
+	topics := []string{}
+	topLevelTopicID := ""
+
+	for i := range rootTopicItems {
+		if strings.ReplaceAll(strings.ToLower(rootTopicItems[i].Title), " ", "") == strings.ToLower(vars["topic"]) {
+			log.Info(ctx, "this the found topic", log.Data{"topics": rootTopicItems[i]})
+			topics = append(topics, rootTopicItems[i].ID)
+			topLevelTopicID = rootTopicItems[i].ID
+			break
+		}
+	}
+
+	subTopics, errrrr := topicC.GetSubtopicsPublic(ctx, topic.Headers{}, topLevelTopicID)
+	if errrrr != nil {
+		log.Error(ctx, "failed to subtopics", errrrr)
+		setStatusCode(w, req, errrrr)
+		return
+	}
+
+	// log.Info(ctx, "this the subtopics", log.Data{"subtopics": subTopics})
+
+	// log.Info(ctx, "this the subtopic", log.Data{"subtopic": vars["subTopic"]})
+
+	rootSubTopicItems := *subTopics.PublicItems
+
+	//REMOVE SPACES FROM TITLE WHEN COMAPRING
+	for i := range rootSubTopicItems {
+		if strings.ReplaceAll(strings.ToLower(rootSubTopicItems[i].Title), " ", "") == strings.ToLower(vars["subTopic"]) {
+			// log.Info(ctx, "this the found subtopic", log.Data{"subtopics": rootSubTopicItems[i]})
+			topics = append(topics, rootSubTopicItems[i].ID)
+			break
+		}
+	}
+
+	defer cancel()
+
+	// log.Info(ctx, "this the topics to be applied to query", log.Data{"topicsids": strings.Join(topics, ",")})
+
+	urlQuery := req.URL.Query()
+
+	urlQuery.Add("topics", strings.Join(topics, ","))
+
+	// replace with new cache
+	censusTopicCache, err := cacheList.CensusTopic.GetCensusData(ctx)
+	if err != nil {
+		log.Error(ctx, "failed to get census topic cache", err)
+		setStatusCode(w, req, err)
+		return
+	}
+
+	log.Info(ctx, "this the census cache topics", log.Data{"topics": censusTopicCache})
+
+	// get cached navigation data
+	navigationCache, err := cacheList.Navigation.GetNavigationData(ctx, lang)
+	if err != nil {
+		log.Error(ctx, "failed to get navigation cache", err)
+		setStatusCode(w, req, err)
+		return
+	}
+
+	validatedQueryParams, err := data.ReviewDataAggregationQueryWithParams(ctx, cfg, urlQuery, censusTopicCache)
+	if err != nil && !errs.ErrMapForRenderBeforeAPICalls[err] {
+		log.Error(ctx, "unable to review query", err)
+		setStatusCode(w, req, err)
+		return
+	}
+
+	// counter used to keep track of the number of concurrent API calls
+	var counter = 3
+
+	searchQuery := data.GetDataAggregationQuery(validatedQueryParams, template)
+	categoriesCountQuery := getCategoriesCountQuery(searchQuery)
+
+	var (
+		homepageResp zebedeeCli.HomepageContent
+		searchResp   = &searchModels.SearchResponse{}
+
+		categories      []data.Category
+		topicCategories []data.Topic
+		populationTypes []data.PopulationTypes
+		dimensions      []data.Dimensions
+
+		wg sync.WaitGroup
+
+		respErr, countErr error
+	)
+	wg.Add(counter)
+
+	go func() {
+		defer wg.Done()
+		var homeErr error
+		homepageResp, homeErr = zc.GetHomepageContent(ctx, accessToken, collectionID, lang, homepagePath)
+		if homeErr != nil {
+			log.Warn(ctx, "unable to get homepage content", log.FormatErrors([]error{err}))
+			return
+		}
+	}()
+
+	var options searchSDK.Options
+
+	options.Query = searchQuery
+
+	options.Headers = http.Header{
+		searchSDK.FlorenceToken: {"Bearer " + accessToken},
+		searchSDK.CollectionID:  {collectionID},
+	}
+
+	go func() {
+		defer wg.Done()
+
+		searchResp, respErr = searchC.GetSearch(ctx, options)
+		if respErr != nil {
+			log.Error(ctx, "getting search response from client failed", respErr)
+			cancel()
+			return
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		// TO-DO: Need to make a second request until API can handle aggregration on datatypes (e.g. bulletins, article) to return counts
+		categories, topicCategories, countErr = getCategoriesTypesCount(ctx, accessToken, collectionID, categoriesCountQuery, searchC, censusTopicCache)
+		if countErr != nil {
+			log.Error(ctx, "getting categories, types and its counts failed", countErr)
+			setStatusCode(w, req, countErr)
+			cancel()
+			return
+		}
+	}()
+
+	wg.Wait()
+	if respErr != nil || countErr != nil {
+		setStatusCode(w, req, respErr)
+		return
+	}
+
+	err = validateCurrentPage(ctx, cfg, validatedQueryParams, searchResp.Count)
+	if err != nil {
+		log.Error(ctx, "unable to validate current page", err)
+		setStatusCode(w, req, err)
+		return
+	}
+	basePage := rend.NewBasePageModel()
+	m := mapper.CreateDataAggregationPage(cfg, req, basePage, validatedQueryParams, categories, topicCategories, populationTypes, dimensions, searchResp, lang, homepageResp, "", navigationCache, template)
+	//time-series-tool needs it's own template due to the need of elements to be present for JS to be able to assign onClick events(doesn't work if they're conditionally shown on the page)
 	if template != "time-series-tool" {
 		rend.BuildPage(w, m, "data-aggregation-page")
 	} else {

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -367,22 +367,7 @@ func readDataAggregationWithTopics(w http.ResponseWriter, req *http.Request, cfg
 		return
 	}
 
-	// log.Info(ctx, "this the root topics", log.Data{"topics": respRootTopics})
-
-	//TODO Loop through topics and compare with vars["topic"]
-	// get the topic to see if subtpic exists GetTopicPublic
-	// if vars["subTopic"] is defined search through the subtopics of the topic
-	// add topic to query and return matched data for topic/subtopic
-	// if topic or subtopic is invalid return defualt data
-
-	// clearTopics := false
-	// if urlQuery.Get("topics") == "" {
-	// 	urlQuery.Add("topics", censusTopicCache.Query)
-	// 	clearTopics = true
-	// }
-
 	rootTopicItems := *respRootTopics.PublicItems
-	// log.Info(ctx, "this the topic items", log.Data{"topics": rootTopicItems})
 	topics := []string{}
 	topLevelTopicID := ""
 
@@ -402,24 +387,16 @@ func readDataAggregationWithTopics(w http.ResponseWriter, req *http.Request, cfg
 		return
 	}
 
-	// log.Info(ctx, "this the subtopics", log.Data{"subtopics": subTopics})
-
-	// log.Info(ctx, "this the subtopic", log.Data{"subtopic": vars["subTopic"]})
-
 	rootSubTopicItems := *subTopics.PublicItems
 
-	//REMOVE SPACES FROM TITLE WHEN COMAPRING
 	for i := range rootSubTopicItems {
 		if strings.ReplaceAll(strings.ToLower(rootSubTopicItems[i].Title), " ", "") == strings.ToLower(vars["subTopic"]) {
-			// log.Info(ctx, "this the found subtopic", log.Data{"subtopics": rootSubTopicItems[i]})
 			topics = append(topics, rootSubTopicItems[i].ID)
 			break
 		}
 	}
 
 	defer cancel()
-
-	// log.Info(ctx, "this the topics to be applied to query", log.Data{"topicsids": strings.Join(topics, ",")})
 
 	urlQuery := req.URL.Query()
 

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -81,11 +81,6 @@ func generateTopicClientMock(topic topicModels.Topic, subTopics []topicModels.To
 	return mockedTopicClient
 }
 
-// func setupTopicCache(cacheTopic *cache.Topic) {
-// 	cacheTopic.UpdateCensusTopic{}
-// 	cacheTopic.List.AppendSubtopicID("5678", cache.Subtopic{ID: "5678", LocaliseKeyName: "Ageing", ReleaseDate: "2022-10-10T09:30:00Z"})
-// }
-
 func TestUnitReadHandlerSuccess(t *testing.T) {
 	t.Parallel()
 

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -18,7 +18,6 @@ import (
 
 	zebedeeC "github.com/ONSdigital/dp-api-clients-go/v2/zebedee"
 	"github.com/ONSdigital/dp-frontend-search-controller/apperrors"
-	errs "github.com/ONSdigital/dp-frontend-search-controller/apperrors"
 	"github.com/ONSdigital/dp-frontend-search-controller/cache"
 	"github.com/ONSdigital/dp-frontend-search-controller/config"
 	"github.com/ONSdigital/dp-frontend-search-controller/data"
@@ -702,7 +701,7 @@ func TestUnitValidateCurrentPageFailure(t *testing.T) {
 
 				Convey("Then return no error", func() {
 					So(err, ShouldNotBeNil)
-					So(err, ShouldResemble, errs.ErrPageExceedsTotalPages)
+					So(err, ShouldResemble, apperrors.ErrPageExceedsTotalPages)
 				})
 			})
 		})
@@ -851,7 +850,7 @@ func TestUnitSetStatusCodeSuccess(t *testing.T) {
 		w := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/search?q=housing&page=1000000", http.NoBody)
 
-		err := errs.ErrInternalServer
+		err := apperrors.ErrInternalServer
 
 		Convey("When setStatusCode is called", func() {
 			setStatusCode(w, req, err)
@@ -881,7 +880,7 @@ func TestUnitSetStatusCodeSuccess(t *testing.T) {
 		w := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/search?q=housing&page=1000000", http.NoBody)
 
-		err := errs.ErrInvalidPage
+		err := apperrors.ErrInvalidPage
 
 		Convey("When setStatusCode is called", func() {
 			setStatusCode(w, req, err)

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -12,8 +12,12 @@ import (
 	searchModels "github.com/ONSdigital/dp-search-api/models"
 	searchSDK "github.com/ONSdigital/dp-search-api/sdk"
 	apiError "github.com/ONSdigital/dp-search-api/sdk/errors"
+	topicModels "github.com/ONSdigital/dp-topic-api/models"
+	topicSDK "github.com/ONSdigital/dp-topic-api/sdk"
+	topicError "github.com/ONSdigital/dp-topic-api/sdk/errors"
 
 	zebedeeC "github.com/ONSdigital/dp-api-clients-go/v2/zebedee"
+	"github.com/ONSdigital/dp-frontend-search-controller/apperrors"
 	errs "github.com/ONSdigital/dp-frontend-search-controller/apperrors"
 	"github.com/ONSdigital/dp-frontend-search-controller/cache"
 	"github.com/ONSdigital/dp-frontend-search-controller/config"
@@ -53,6 +57,30 @@ var (
 		List:            &cache.Subtopics{},
 	}
 )
+
+func generateTopicClientMock(topic topicModels.Topic, subTopics []topicModels.Topic) *TopicClientMock {
+	mockedTopicClient := &TopicClientMock{
+		GetRootTopicsPublicFunc: func(ctx context.Context, reqHeaders topicSDK.Headers) (*topicModels.PublicSubtopics, topicError.Error) {
+			return &topicModels.PublicSubtopics{
+				Count: 2,
+				PublicItems: &[]topicModels.Topic{
+					topic,
+				},
+			}, nil
+		},
+		GetTopicPublicFunc: func(ctx context.Context, reqHeaders topicSDK.Headers, id string) (*topicModels.Topic, topicError.Error) {
+			return &topic, nil
+		},
+		GetSubtopicsPublicFunc: func(ctx context.Context, reqHeaders topicSDK.Headers, id string) (*topicModels.PublicSubtopics, topicError.Error) {
+			return &topicModels.PublicSubtopics{
+				Count:       2,
+				PublicItems: &subTopics,
+			}, nil
+		},
+	}
+
+	return mockedTopicClient
+}
 
 // func setupTopicCache(cacheTopic *cache.Topic) {
 // 	cacheTopic.UpdateCensusTopic{}
@@ -100,7 +128,9 @@ func TestUnitReadHandlerSuccess(t *testing.T) {
 			},
 		}
 
-		mockHandlerClients := NewHandlerClients(mockedRendererClient, mockedSearchClient, mockedZebedeeClient)
+		mockedTopicClient := &TopicClientMock{}
+
+		mockHandlerClients := NewHandlerClients(mockedRendererClient, mockedSearchClient, mockedZebedeeClient, mockedTopicClient)
 
 		mockCacheList, err := cache.GetMockCacheList(ctx, englishLang)
 		So(err, ShouldBeNil)
@@ -347,6 +377,261 @@ func TestUnitReadFailure(t *testing.T) {
 				So(mockedRendererClient.BuildPageCalls(), ShouldHaveLength, 0)
 				So(mockedSearchClient.GetSearchCalls(), ShouldHaveLength, 2)
 				So(mockedZebedeeClient.GetHomepageContentCalls(), ShouldHaveLength, 1)
+			})
+		})
+	})
+}
+
+func TestUnitReadDataAggregationWithTopicsSuccess(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	mockSearchResponse, err := mapper.GetMockSearchResponse()
+	if err != nil {
+		t.Errorf("failed to retrieve mock search response for unit tests, failing early: %v", err)
+	}
+
+	mockHomepageContent, err := mapper.GetMockHomepageContent()
+	if err != nil {
+		t.Errorf("failed to retrieve mock homepage content for unit tests, failing early: %v", err)
+	}
+
+	Convey("Given a valid request for a topic filtered page and a set of mocked services", t, func() {
+		testTopic := topicModels.Topic{
+			ID:    "1234",
+			Title: "economy",
+		}
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", fmt.Sprintf("/%s/publications", testTopic.Title), http.NoBody)
+		req = mux.SetURLVars(req, map[string]string{"topic": testTopic.Title})
+
+		cfg, err := config.Get()
+		So(err, ShouldBeNil)
+
+		mockedRendererClient := &RenderClientMock{
+			BuildPageFunc: func(w io.Writer, pageModel interface{}, templateName string) {},
+			NewBasePageModelFunc: func() coreModel.Page {
+				return coreModel.Page{}
+			},
+		}
+
+		mockedSearchClient := &SearchClientMock{
+			GetSearchFunc: func(ctx context.Context, options searchSDK.Options) (*searchModels.SearchResponse, apiError.Error) {
+				return mockSearchResponse, nil
+			},
+		}
+
+		mockedZebedeeClient := &ZebedeeClientMock{
+			GetHomepageContentFunc: func(ctx context.Context, userAuthToken, collectionID, lang, path string) (zebedeeC.HomepageContent, error) {
+				return mockHomepageContent, nil
+			},
+		}
+
+		mockedTopicClient := generateTopicClientMock(testTopic, nil)
+
+		mockCacheList, err := cache.GetMockCacheList(ctx, englishLang)
+		So(err, ShouldBeNil)
+
+		Convey("When readDataAggregationWithTopics is called", func() {
+			readDataAggregationWithTopics(w, req, cfg, mockedZebedeeClient, mockedRendererClient, mockedSearchClient, mockedTopicClient, accessToken, collectionID, englishLang, *mockCacheList, "publications")
+
+			Convey("Then a 200 OK status should be returned", func() {
+				So(w.Code, ShouldEqual, http.StatusOK)
+
+				So(mockedRendererClient.BuildPageCalls(), ShouldHaveLength, 1)
+				So(mockedSearchClient.GetSearchCalls(), ShouldHaveLength, 2)
+				So(mockedZebedeeClient.GetHomepageContentCalls(), ShouldHaveLength, 1)
+				So(mockedTopicClient.GetRootTopicsPublicCalls(), ShouldHaveLength, 1)
+				So(mockedTopicClient.GetSubtopicsPublicCalls(), ShouldHaveLength, 0)
+			})
+
+			Convey("And the Search Client should be called with the topic id from the topic API", func() {
+				So(mockedSearchClient.calls.GetSearch[1].Options.Query.Get("topics"), ShouldEqual, testTopic.ID)
+			})
+		})
+	})
+
+	Convey("Given a valid request for a subtopic filtered page and a set of mocked services", t, func() {
+		testTopic := topicModels.Topic{
+			ID:    "1234",
+			Title: "economy",
+		}
+
+		testSubtopic := topicModels.Topic{
+			ID:    "1235",
+			Title: "environmental",
+		}
+
+		testSubtopics := []topicModels.Topic{
+			testSubtopic,
+		}
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", fmt.Sprintf("/%s/%s/publications", testTopic.Title, testSubtopic.Title), http.NoBody)
+		req = mux.SetURLVars(req, map[string]string{"topic": testTopic.Title, "subTopic": testSubtopic.Title})
+
+		cfg, err := config.Get()
+		So(err, ShouldBeNil)
+
+		mockedRendererClient := &RenderClientMock{
+			BuildPageFunc: func(w io.Writer, pageModel interface{}, templateName string) {},
+			NewBasePageModelFunc: func() coreModel.Page {
+				return coreModel.Page{}
+			},
+		}
+
+		mockedSearchClient := &SearchClientMock{
+			GetSearchFunc: func(ctx context.Context, options searchSDK.Options) (*searchModels.SearchResponse, apiError.Error) {
+				return mockSearchResponse, nil
+			},
+		}
+
+		mockedZebedeeClient := &ZebedeeClientMock{
+			GetHomepageContentFunc: func(ctx context.Context, userAuthToken, collectionID, lang, path string) (zebedeeC.HomepageContent, error) {
+				return mockHomepageContent, nil
+			},
+		}
+
+		mockedTopicClient := generateTopicClientMock(testTopic, testSubtopics)
+
+		mockCacheList, err := cache.GetMockCacheList(ctx, englishLang)
+		So(err, ShouldBeNil)
+
+		Convey("When readDataAggregationWithTopics is called", func() {
+			readDataAggregationWithTopics(w, req, cfg, mockedZebedeeClient, mockedRendererClient, mockedSearchClient, mockedTopicClient, accessToken, collectionID, englishLang, *mockCacheList, "publications")
+
+			Convey("Then a 200 OK status should be returned", func() {
+				So(w.Code, ShouldEqual, http.StatusOK)
+
+				So(mockedRendererClient.BuildPageCalls(), ShouldHaveLength, 1)
+				So(mockedSearchClient.GetSearchCalls(), ShouldHaveLength, 2)
+				So(mockedZebedeeClient.GetHomepageContentCalls(), ShouldHaveLength, 1)
+				So(mockedTopicClient.GetRootTopicsPublicCalls(), ShouldHaveLength, 1)
+				So(mockedTopicClient.GetSubtopicsPublicCalls(), ShouldHaveLength, 1)
+			})
+
+			Convey("And the Search Client should be called with the subtopic id from the topic API", func() {
+				So(mockedSearchClient.calls.GetSearch[1].Options.Query.Get("topics"), ShouldEqual, testSubtopic.ID)
+			})
+		})
+	})
+}
+
+func TestUnitReadDataAggregationWithTopicsFailure(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	mockSearchResponse, err := mapper.GetMockSearchResponse()
+	if err != nil {
+		t.Errorf("failed to retrieve mock search response for unit tests, failing early: %v", err)
+	}
+
+	mockHomepageContent, err := mapper.GetMockHomepageContent()
+	if err != nil {
+		t.Errorf("failed to retrieve mock homepage content for unit tests, failing early: %v", err)
+	}
+
+	Convey("Given a request for a topic filtered page and a set of mocked services where the topic does not exist", t, func() {
+		testTopic := "thisdoesnotexist"
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", fmt.Sprintf("/%s/publications", testTopic), http.NoBody)
+		req = mux.SetURLVars(req, map[string]string{"topic": testTopic})
+
+		cfg, err := config.Get()
+		So(err, ShouldBeNil)
+
+		mockedRendererClient := &RenderClientMock{
+			BuildPageFunc: func(w io.Writer, pageModel interface{}, templateName string) {},
+			NewBasePageModelFunc: func() coreModel.Page {
+				return coreModel.Page{}
+			},
+		}
+
+		mockedSearchClient := &SearchClientMock{
+			GetSearchFunc: func(ctx context.Context, options searchSDK.Options) (*searchModels.SearchResponse, apiError.Error) {
+				return mockSearchResponse, nil
+			},
+		}
+
+		mockedZebedeeClient := &ZebedeeClientMock{
+			GetHomepageContentFunc: func(ctx context.Context, userAuthToken, collectionID, lang, path string) (zebedeeC.HomepageContent, error) {
+				return mockHomepageContent, nil
+			},
+		}
+
+		mockedTopicClient := generateTopicClientMock(topicModels.Topic{}, []topicModels.Topic{})
+
+		mockCacheList, err := cache.GetMockCacheList(ctx, englishLang)
+		So(err, ShouldBeNil)
+
+		Convey("When readDataAggregationWithTopics is called", func() {
+			readDataAggregationWithTopics(w, req, cfg, mockedZebedeeClient, mockedRendererClient, mockedSearchClient, mockedTopicClient, accessToken, collectionID, englishLang, *mockCacheList, "publications")
+
+			Convey("Then a 404 OK status should be returned", func() {
+				So(w.Code, ShouldEqual, http.StatusNotFound)
+
+				So(mockedRendererClient.BuildPageCalls(), ShouldHaveLength, 0)
+				So(mockedSearchClient.GetSearchCalls(), ShouldHaveLength, 0)
+				So(mockedZebedeeClient.GetHomepageContentCalls(), ShouldHaveLength, 0)
+				So(mockedTopicClient.GetRootTopicsPublicCalls(), ShouldHaveLength, 1)
+				So(mockedTopicClient.GetSubtopicsPublicCalls(), ShouldHaveLength, 0)
+			})
+		})
+	})
+
+	Convey("Given a request for a subtopic filtered page and a set of mocked services where the subtopic does not exist", t, func() {
+		testTopic := topicModels.Topic{
+			ID:    "1234",
+			Title: "economy",
+		}
+		testSubtopic := "thissubtopicdoesnotexist"
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", fmt.Sprintf("/%s/%s/publications", testTopic.Title, testSubtopic), http.NoBody)
+		req = mux.SetURLVars(req, map[string]string{"topic": testTopic.Title, "subTopic": testSubtopic})
+
+		cfg, err := config.Get()
+		So(err, ShouldBeNil)
+
+		mockedRendererClient := &RenderClientMock{
+			BuildPageFunc: func(w io.Writer, pageModel interface{}, templateName string) {},
+			NewBasePageModelFunc: func() coreModel.Page {
+				return coreModel.Page{}
+			},
+		}
+
+		mockedSearchClient := &SearchClientMock{
+			GetSearchFunc: func(ctx context.Context, options searchSDK.Options) (*searchModels.SearchResponse, apiError.Error) {
+				return mockSearchResponse, nil
+			},
+		}
+
+		mockedZebedeeClient := &ZebedeeClientMock{
+			GetHomepageContentFunc: func(ctx context.Context, userAuthToken, collectionID, lang, path string) (zebedeeC.HomepageContent, error) {
+				return mockHomepageContent, nil
+			},
+		}
+
+		mockedTopicClient := generateTopicClientMock(testTopic, []topicModels.Topic{})
+
+		mockCacheList, err := cache.GetMockCacheList(ctx, englishLang)
+		So(err, ShouldBeNil)
+
+		Convey("When readDataAggregationWithTopics is called", func() {
+			readDataAggregationWithTopics(w, req, cfg, mockedZebedeeClient, mockedRendererClient, mockedSearchClient, mockedTopicClient, accessToken, collectionID, englishLang, *mockCacheList, "publications")
+
+			Convey("Then a 404 OK status should be returned", func() {
+				So(w.Code, ShouldEqual, http.StatusNotFound)
+
+				So(mockedRendererClient.BuildPageCalls(), ShouldHaveLength, 0)
+				So(mockedSearchClient.GetSearchCalls(), ShouldHaveLength, 0)
+				So(mockedZebedeeClient.GetHomepageContentCalls(), ShouldHaveLength, 0)
+				So(mockedTopicClient.GetRootTopicsPublicCalls(), ShouldHaveLength, 1)
+				So(mockedTopicClient.GetSubtopicsPublicCalls(), ShouldHaveLength, 1)
 			})
 		})
 	})
@@ -683,6 +968,82 @@ func TestCreateRSSFeed(t *testing.T) {
 
 		Convey("it should return an error", func() {
 			So(err, ShouldNotBeNil)
+func TestGetTopicByURLString(t *testing.T) {
+	t.Parallel()
+
+	Convey("Given some topics and a matching URL path", t, func() {
+		topicPath := "economy"
+
+		expectedTopic := topicModels.Topic{
+			Title: "Economy",
+			ID:    "6646",
+		}
+
+		topics := []topicModels.Topic{
+			{
+				Title: "business",
+				ID:    "6657",
+			},
+			expectedTopic,
+		}
+
+		Convey("When GetTopicByURLString is called", func() {
+			actual, err := getTopicByURLString(topicPath, topics)
+
+			Convey("Then the expected topic is returned", func() {
+				So(actual, ShouldEqual, expectedTopic)
+				So(err, ShouldBeNil)
+			})
+		})
+	})
+
+	Convey("Given some topics and a non-matching URL path", t, func() {
+		topicPath := "thiswill404"
+
+		topics := []topicModels.Topic{
+			{
+				Title: "business",
+				ID:    "6657",
+			},
+			{
+				Title: "economy",
+				ID:    "6646",
+			},
+		}
+
+		Convey("When GetTopicByURLString is called", func() {
+			actual, err := getTopicByURLString(topicPath, topics)
+
+			Convey("Then a TopicPath Not Found error is thrown", func() {
+				So(actual, ShouldEqual, topicModels.Topic{})
+				So(err, ShouldEqual, apperrors.ErrTopicPathNotFound)
+			})
+		})
+	})
+
+	Convey("Given a topic with special characters and a matching URL path", t, func() {
+		topicPath := "businessindustryandtrade"
+
+		expectedTopic := topicModels.Topic{
+			Title: "Business, industry and Trade",
+			ID:    "6646",
+		}
+
+		topics := []topicModels.Topic{
+			{
+				Title: "business",
+				ID:    "6657",
+			},
+			expectedTopic,
+		}
+
+		Convey("When GetTopicByURLString is called", func() {
+			actual, err := getTopicByURLString(topicPath, topics)
+
+			Convey("Then the expected topic is returned", func() {
+				So(actual, ShouldEqual, expectedTopic)
+				So(err, ShouldBeNil)
+			})
 		})
 	})
 }

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -967,6 +967,10 @@ func TestCreateRSSFeed(t *testing.T) {
 
 		Convey("it should return an error", func() {
 			So(err, ShouldNotBeNil)
+		})
+	})
+}
+
 func TestGetTopicByURLString(t *testing.T) {
 	t.Parallel()
 

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -442,7 +442,18 @@ func TestUnitReadDataAggregationWithTopicsSuccess(t *testing.T) {
 			})
 
 			Convey("And the Search Client should be called with the topic id from the topic API", func() {
-				So(mockedSearchClient.calls.GetSearch[1].Options.Query.Get("topics"), ShouldEqual, testTopic.ID)
+				// calls go to client in parallel, so we need to work out which is which.
+				firstSearchCall := mockedSearchClient.GetSearchCalls()[0]
+				secondSearchCall := mockedSearchClient.GetSearchCalls()[1]
+
+				firstCallTopic := firstSearchCall.Options.Query.Get("topics")
+				secondCallTopic := secondSearchCall.Options.Query.Get("topics")
+
+				if firstCallTopic != "" {
+					So(firstCallTopic, ShouldEqual, testTopic.ID)
+				} else {
+					So(secondCallTopic, ShouldEqual, testTopic.ID)
+				}
 			})
 		})
 	})
@@ -507,7 +518,18 @@ func TestUnitReadDataAggregationWithTopicsSuccess(t *testing.T) {
 			})
 
 			Convey("And the Search Client should be called with the subtopic id from the topic API", func() {
-				So(mockedSearchClient.calls.GetSearch[1].Options.Query.Get("topics"), ShouldEqual, testSubtopic.ID)
+				// calls go to client in parallel, so we need to work out which is which.
+				firstSearchCall := mockedSearchClient.GetSearchCalls()[0]
+				secondSearchCall := mockedSearchClient.GetSearchCalls()[1]
+
+				firstCallTopic := firstSearchCall.Options.Query.Get("topics")
+				secondCallTopic := secondSearchCall.Options.Query.Get("topics")
+
+				if firstCallTopic != "" {
+					So(firstCallTopic, ShouldEqual, testSubtopic.ID)
+				} else {
+					So(secondCallTopic, ShouldEqual, testSubtopic.ID)
+				}
 			})
 		})
 	})

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -66,7 +66,7 @@ func CreateSearchPage(cfg *config.Config, req *http.Request, basePage coreModel.
 
 // CreateDataAggregationPage maps type searchC.Response to model.Page
 func CreateDataAggregationPage(cfg *config.Config, req *http.Request, basePage coreModel.Page,
-	validatedQueryParams data.SearchURLParams, categories []data.Category, topicCategories []data.Topic, _ []data.PopulationTypes, _ []data.Dimensions,
+	validatedQueryParams data.SearchURLParams, categories []data.Category, topicCategories []data.Topic,
 	respC *searchModels.SearchResponse, lang string, homepageResponse zebedee.HomepageContent, errorMessage string,
 	navigationContent *topicModel.Navigation,
 	template string, topic topicModel.Topic,

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -69,7 +69,7 @@ func CreateDataAggregationPage(cfg *config.Config, req *http.Request, basePage c
 	validatedQueryParams data.SearchURLParams, categories []data.Category, topicCategories []data.Topic, _ []data.PopulationTypes, _ []data.Dimensions,
 	respC *searchModels.SearchResponse, lang string, homepageResponse zebedee.HomepageContent, errorMessage string,
 	navigationContent *topicModel.Navigation,
-	template string,
+	template string, topic topicModel.Topic,
 ) model.SearchPage {
 	page := model.SearchPage{
 		Page: basePage,
@@ -78,7 +78,7 @@ func CreateDataAggregationPage(cfg *config.Config, req *http.Request, basePage c
 
 	MapCookiePreferences(req, &page.Page.CookiesPreferencesSet, &page.Page.CookiesPolicy)
 
-	mapDataPage(&page, respC, lang, req, cfg, validatedQueryParams, homepageResponse, navigationContent, template)
+	mapDataPage(&page, respC, lang, req, cfg, validatedQueryParams, homepageResponse, navigationContent, template, topic)
 
 	mapQuery(cfg, &page, validatedQueryParams, respC, *req, errorMessage)
 
@@ -91,7 +91,7 @@ func CreateDataAggregationPage(cfg *config.Config, req *http.Request, basePage c
 	return page
 }
 
-func mapDataPage(page *model.SearchPage, respC *searchModels.SearchResponse, lang string, req *http.Request, cfg *config.Config, validatedQueryParams data.SearchURLParams, homepageResponse zebedee.HomepageContent, navigationContent *topicModel.Navigation, template string) {
+func mapDataPage(page *model.SearchPage, respC *searchModels.SearchResponse, lang string, req *http.Request, cfg *config.Config, validatedQueryParams data.SearchURLParams, homepageResponse zebedee.HomepageContent, navigationContent *topicModel.Navigation, template string, topic topicModel.Topic) {
 	switch template {
 	case "all-adhocs":
 		page.Metadata.Title = "User requested data"
@@ -182,6 +182,7 @@ func mapDataPage(page *model.SearchPage, respC *searchModels.SearchResponse, lan
 	}
 
 	page.Type = "Data Aggregation Page"
+	page.Data.Topic = strings.ToLower(topic.Title)
 	page.Data.TermLocalKey = "Results"
 	page.Count = respC.Count
 	page.Language = lang

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ONSdigital/dp-frontend-search-controller/config"
 	"github.com/ONSdigital/dp-frontend-search-controller/data"
 	"github.com/ONSdigital/dp-renderer/v2/model"
-	"github.com/ONSdigital/dp-topic-api/models"
+	topicModels "github.com/ONSdigital/dp-topic-api/models"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -68,7 +68,7 @@ func TestUnitCreateSearchPage(t *testing.T) {
 			// NOTE: temporary measure until topic filter feature flag is removed
 			cfg.EnableCensusTopicFilterOption = true
 
-			sp := CreateSearchPage(cfg, req, mdl, validatedQueryParams, categories, topicCategories, respC, englishLang, respH, "", &models.Navigation{})
+			sp := CreateSearchPage(cfg, req, mdl, validatedQueryParams, categories, topicCategories, respC, englishLang, respH, "", &topicModels.Navigation{})
 
 			Convey("Then successfully map search response from search-query client to page model", func() {
 				So(sp.Data.Query, ShouldEqual, "housing")
@@ -209,7 +209,7 @@ func TestUnitFindDatasetPage(t *testing.T) {
 			cfg.EnableCensusPopulationTypesFilterOption = true
 			cfg.EnableCensusDimensionsFilterOption = true
 
-			sp := CreateDataFinderPage(cfg, req, mdl, validatedQueryParams, categories, topicCategories, populationTypes, dimensions, respC, englishLang, respH, "", &models.Navigation{})
+			sp := CreateDataFinderPage(cfg, req, mdl, validatedQueryParams, categories, topicCategories, populationTypes, dimensions, respC, englishLang, respH, "", &topicModels.Navigation{})
 
 			Convey("Then successfully map search response from search-query client to page model", func() {
 				So(sp.Data.Query, ShouldEqual, "housing")
@@ -361,7 +361,7 @@ func TestCreateDataAggregationPage(t *testing.T) {
 		}
 
 		Convey("When CreateDataAggregationPage is called", func() {
-			sp := CreateDataAggregationPage(cfg, req, mdl, validatedQueryParams, categories, topicCategories, []data.PopulationTypes{}, []data.Dimensions{}, respC, englishLang, respH, "", &models.Navigation{}, "")
+			sp := CreateDataAggregationPage(cfg, req, mdl, validatedQueryParams, categories, topicCategories, respC, englishLang, respH, "", &topicModels.Navigation{}, "", topicModels.Topic{})
 
 			Convey("Then successfully map core features to the page model", func() {
 				// keyword search
@@ -443,7 +443,7 @@ func TestCreateDataAggregationPage(t *testing.T) {
 
 			for _, tc := range testcases {
 				Convey(fmt.Sprintf("Then page template: %s maps the page features correctly", tc.template), func() {
-					sp := CreateDataAggregationPage(cfg, req, mdl, validatedQueryParams, categories, topicCategories, []data.PopulationTypes{}, []data.Dimensions{}, respC, englishLang, respH, "", &models.Navigation{}, tc.template)
+					sp := CreateDataAggregationPage(cfg, req, mdl, validatedQueryParams, categories, topicCategories, respC, englishLang, respH, "", &topicModels.Navigation{}, tc.template, topicModels.Topic{})
 					So(sp.Metadata.Title, ShouldEqual, tc.exTitle)
 					So(sp.Title.LocaliseKeyName, ShouldEqual, tc.exLocaliseKeyName)
 					So(sp.Data.SingleContentTypeFilterEnabled, ShouldEqual, tc.exSingleContentTypeFilterEnabled)

--- a/model/search.go
+++ b/model/search.go
@@ -36,6 +36,7 @@ type Search struct {
 	Pagination                     model.Pagination       `json:"pagination,omitempty"`
 	Response                       Response               `json:"response"`
 	TermLocalKey                   string                 `json:"term_localise_key_name,omitempty"`
+	Topic                          string                 `json:"topic,omitempty"`
 }
 
 // Filter respresents all filter information needed by templates

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -28,7 +28,7 @@ type Clients struct {
 func Setup(ctx context.Context, r *mux.Router, cfg *config.Config, c Clients, cacheList cache.List) {
 	log.Info(ctx, "adding routes")
 	r.StrictSlash(true).Path("/health").HandlerFunc(c.HealthCheckHandler)
-	hc := handlers.NewHandlerClients(c.Renderer, c.Search, c.Zebedee)
+	hc := handlers.NewHandlerClients(c.Renderer, c.Search, c.Zebedee, c.Topic)
 	r.StrictSlash(true).Path("/search").Methods("GET").HandlerFunc(handlers.Read(cfg, hc, cacheList, "search"))
 
 	if cfg.EnableReworkedDataAggregationPages {
@@ -40,6 +40,22 @@ func Setup(ctx context.Context, r *mux.Router, cfg *config.Config, c Clients, ca
 		r.StrictSlash(true).Path("/timeseriestool").Methods("GET").HandlerFunc(handlers.ReadDataAggregation(cfg, hc, cacheList, "time-series-tool"))
 		r.StrictSlash(true).Path("/publications").Methods("GET").HandlerFunc(handlers.ReadDataAggregation(cfg, hc, cacheList, "home-publications"))
 		r.StrictSlash(true).Path("/allmethodologies").Methods("GET").HandlerFunc(handlers.ReadDataAggregation(cfg, hc, cacheList, "all-methodologies"))
+
+		//datalist
+		r.StrictSlash(true).Path("/{topic}/datalist").Methods("GET").HandlerFunc(handlers.ReadDataAggregationWithTopics(cfg, hc, cacheList, "home-datalist"))
+		r.StrictSlash(true).Path("/{topic}/{subTopic}/datalist").Methods("GET").HandlerFunc(handlers.ReadDataAggregationWithTopics(cfg, hc, cacheList, "home-datalist"))
+
+		//publications
+		r.StrictSlash(true).Path("/{topic}/publications").Methods("GET").HandlerFunc(handlers.ReadDataAggregationWithTopics(cfg, hc, cacheList, "home-publications"))
+		r.StrictSlash(true).Path("/{topic}/{subTopic}/publications").Methods("GET").HandlerFunc(handlers.ReadDataAggregationWithTopics(cfg, hc, cacheList, "home-publications"))
+
+		//staticlist
+		r.StrictSlash(true).Path("/{topic}/staticlist").Methods("GET").HandlerFunc(handlers.ReadDataAggregationWithTopics(cfg, hc, cacheList, "home-list"))
+		r.StrictSlash(true).Path("/{topic}/{subTopic}/staticlist").Methods("GET").HandlerFunc(handlers.ReadDataAggregationWithTopics(cfg, hc, cacheList, "home-list"))
+
+		//topicspecificmethodology
+		r.StrictSlash(true).Path("/{topic}/topicspecificmethodology").Methods("GET").HandlerFunc(handlers.ReadDataAggregationWithTopics(cfg, hc, cacheList, "home-methodology"))
+		r.StrictSlash(true).Path("/{topic}/{subTopic}/topicspecificmethodology").Methods("GET").HandlerFunc(handlers.ReadDataAggregationWithTopics(cfg, hc, cacheList, "home-methodology"))
 	}
 
 	r.StrictSlash(true).Path("/census/find-a-dataset").Methods("GET").HandlerFunc(handlers.ReadFindDataset(cfg, hc, cacheList))

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -41,19 +41,19 @@ func Setup(ctx context.Context, r *mux.Router, cfg *config.Config, c Clients, ca
 		r.StrictSlash(true).Path("/publications").Methods("GET").HandlerFunc(handlers.ReadDataAggregation(cfg, hc, cacheList, "home-publications"))
 		r.StrictSlash(true).Path("/allmethodologies").Methods("GET").HandlerFunc(handlers.ReadDataAggregation(cfg, hc, cacheList, "all-methodologies"))
 
-		//datalist
+		// datalist
 		r.StrictSlash(true).Path("/{topic}/datalist").Methods("GET").HandlerFunc(handlers.ReadDataAggregationWithTopics(cfg, hc, cacheList, "home-datalist"))
 		r.StrictSlash(true).Path("/{topic}/{subTopic}/datalist").Methods("GET").HandlerFunc(handlers.ReadDataAggregationWithTopics(cfg, hc, cacheList, "home-datalist"))
 
-		//publications
+		// publications
 		r.StrictSlash(true).Path("/{topic}/publications").Methods("GET").HandlerFunc(handlers.ReadDataAggregationWithTopics(cfg, hc, cacheList, "home-publications"))
 		r.StrictSlash(true).Path("/{topic}/{subTopic}/publications").Methods("GET").HandlerFunc(handlers.ReadDataAggregationWithTopics(cfg, hc, cacheList, "home-publications"))
 
-		//staticlist
+		// staticlist
 		r.StrictSlash(true).Path("/{topic}/staticlist").Methods("GET").HandlerFunc(handlers.ReadDataAggregationWithTopics(cfg, hc, cacheList, "home-list"))
 		r.StrictSlash(true).Path("/{topic}/{subTopic}/staticlist").Methods("GET").HandlerFunc(handlers.ReadDataAggregationWithTopics(cfg, hc, cacheList, "home-list"))
 
-		//topicspecificmethodology
+		// topicspecificmethodology
 		r.StrictSlash(true).Path("/{topic}/topicspecificmethodology").Methods("GET").HandlerFunc(handlers.ReadDataAggregationWithTopics(cfg, hc, cacheList, "home-methodology"))
 		r.StrictSlash(true).Path("/{topic}/{subTopic}/topicspecificmethodology").Methods("GET").HandlerFunc(handlers.ReadDataAggregationWithTopics(cfg, hc, cacheList, "home-methodology"))
 	}


### PR DESCRIPTION
### What

Porting code from F&T for handling params in data aggregation routes. 
Currently does not cache topics, not does it go three layers deep. 

Also:
- removed populationTypes and dimensions from aggregated Data pages as not relevant. 
- added dynamic titles based on topic name

The aim of this PR was to get F&Ts code into some kind of working baseline which we can build from.

### How to review

Switch on aggregated pages
Port forward dp-api-router to sandbox address

Check topic filtered pages like:

/economy/publications
/economy/environmentalaccounts/publications

### Who can review

Not me. 