### PR TITLE
Fix/date filters

### DIFF
--- a/data/query.go
+++ b/data/query.go
@@ -242,12 +242,12 @@ func GetDates(ctx context.Context, params url.Values) (startDate, endDate Date, 
 	)
 
 	const (
-		DayBefore   = "before-day"
-		DayAfter    = "after-day"
-		MonthBefore = "before-month"
-		MonthAfter  = "after-month"
-		YearBefore  = "before-year"
-		YearAfter   = "after-year"
+		DayBefore   = "toDateDay"
+		DayAfter    = "fromDateDay"
+		MonthBefore = "toDateMonth"
+		MonthAfter  = "fromDateMonth"
+		YearBefore  = "toDateYear"
+		YearAfter   = "fromDateYear"
 		DateFrom    = "fromDate"
 		DateTo      = "toDate"
 	)

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -140,7 +140,7 @@ func mapDataPage(page *model.SearchPage, respC *searchModels.SearchResponse, lan
 		SearchTerm: validatedQueryParams.Query,
 	}
 
-	page.Data.BeforeDate = coreModel.DateFieldset{
+	page.Data.AfterDate = coreModel.DateFieldset{
 		Input: coreModel.InputDate{
 			Language:        lang,
 			Id:              "from-date-filters",
@@ -161,7 +161,7 @@ func mapDataPage(page *model.SearchPage, respC *searchModels.SearchResponse, lan
 		},
 	}
 
-	page.Data.AfterDate = coreModel.DateFieldset{
+	page.Data.BeforeDate = coreModel.DateFieldset{
 		Input: coreModel.InputDate{
 			Language:        lang,
 			Id:              "to-date-filters",

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -317,7 +317,7 @@ func TestCreateDataAggregationPage(t *testing.T) {
 			SearchTerm: validatedQueryParams.Query,
 		}
 
-		mockBeforeDate := model.DateFieldset{
+		mockAfterDate := model.DateFieldset{
 			Input: model.InputDate{
 				Language:        englishLang,
 				Id:              "from-date-filters",
@@ -339,7 +339,7 @@ func TestCreateDataAggregationPage(t *testing.T) {
 			},
 		}
 
-		mockAfterDate := model.DateFieldset{
+		mockBeforeDate := model.DateFieldset{
 			Input: model.InputDate{
 				Language:        englishLang,
 				Id:              "to-date-filters",


### PR DESCRIPTION
### What

Two small changes:
- Switch `BeforeDate` and `AfterDate` to correct fields
- Rename date query params to match mapper date params

### How to review

Pull this branch and run app make debug ENABLE_REWORKED_DATA_AGGREGATION_PAGES=true
Run dp-design-system
Port forward the api router to sandbox dp ssh sandbox web 1 -p 23200:localhost:10800
Pages:

https://dp.aws.onsdigital.uk/allmethodologies
https://dp.aws.onsdigital.uk/datalist
https://dp.aws.onsdigital.uk/timeseriestool
https://dp.aws.onsdigital.uk/publications
https://dp.aws.onsdigital.uk/staticlist
https://dp.aws.onsdigital.uk/topicspecificmethodology
https://dp.aws.onsdigital.uk/alladhocs
https://dp.aws.onsdigital.uk/publishedrequests

Check date fields are the correct way round.
Date inputs retain values.
Sense check.

### Who can review

Anyone
