### PR TITLE
Filter unrecognised filter logging for known unused filters

### DIFF
--- a/data/filter.go
+++ b/data/filter.go
@@ -70,6 +70,10 @@ var (
 		ContentTypes:    []ContentType{Methodology, CorporateInformation, ProductPage},
 	}
 
+	// UnusedCategories - these categories are served from the Search API but we don't use them for filters.
+	// If left in, they create noise in the logs about unexpected filters being returned.
+	UnusedCategoryTypes = []string{"release", "visualisation", "api_dataset_landing_page", "compendium_chapter", "dataset", "taxonomy_landing_page"}
+
 	// Bulletin - Search information specific for statistical bulletins
 	Bulletin = ContentType{
 		LocaliseKeyName: "StatisticalBulletin",
@@ -247,4 +251,14 @@ func GetGroupLocaliseKey(resultType string) string {
 		}
 	}
 	return ""
+}
+
+// IsCategoryUnused returns if a category is unused.
+func IsCategoryUnused(categoryName string) bool {
+	for _, val := range UnusedCategoryTypes {
+		if val == categoryName {
+			return true
+		}
+	}
+	return false
 }

--- a/data/filter_test.go
+++ b/data/filter_test.go
@@ -316,3 +316,43 @@ func TestUnitGetGroupLocaliseKey(t *testing.T) {
 		})
 	})
 }
+
+func TestUnitIsCategoryUnused(t *testing.T) {
+	t.Parallel()
+
+	Convey("Given a category that is used", t, func() {
+		category := "static_methodology"
+
+		Convey("When IsCategoryUnused is called", func() {
+			isCategoryUnused := IsCategoryUnused(category)
+
+			Convey("Then it should return false", func() {
+				So(isCategoryUnused, ShouldBeFalse)
+			})
+		})
+	})
+
+	Convey("Given a category that is unused", t, func() {
+		category := "visualisation"
+
+		Convey("When IsCategoryUnused is called", func() {
+			isCategoryUnused := IsCategoryUnused(category)
+
+			Convey("Then it should return true", func() {
+				So(isCategoryUnused, ShouldBeTrue)
+			})
+		})
+	})
+
+	Convey("Given a category that is unknown", t, func() {
+		category := "visualisation"
+
+		Convey("When IsCategoryUnused is called", func() {
+			isCategoryUnused := IsCategoryUnused(category)
+
+			Convey("Then it should return false", func() {
+				So(isCategoryUnused, ShouldBeTrue)
+			})
+		})
+	})
+}

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -743,7 +743,7 @@ func setCountToCategories(ctx context.Context, countResp *searchModels.SearchRes
 			}
 		}
 
-		if !foundFilter {
+		if !foundFilter && !data.IsCategoryUnused(responseType.Type) {
 			log.Warn(ctx, "unrecognised filter type returned from api", log.Data{"filter_type": responseType.Type})
 		}
 	}


### PR DESCRIPTION
### What

Added a known list of unused content type filters - this will reduce overall logging by the app by around 300K log entries a day. 

### How to review

Run the app, port forward to api router in aws and check for 'unrecognised filter type returned from api'. Should be none. Check remaining filters still work. 

### Who can review

Not me. 