### PR TITLE
Fix/remove excess logging2

### DIFF
--- a/data/pagination.go
+++ b/data/pagination.go
@@ -42,7 +42,13 @@ func reviewPagination(ctx context.Context, cfg *config.Config, urlQuery url.Valu
 }
 
 func getLimitFromURLQuery(ctx context.Context, cfg *config.Config, query url.Values) int {
-	limit, err := strconv.Atoi(query.Get("limit"))
+	limitParam := query.Get("limit")
+
+	if limitParam == "" {
+		return cfg.DefaultLimit
+	}
+
+	limit, err := strconv.Atoi(limitParam)
 	if err != nil {
 		log.Info(ctx, fmt.Sprintf("unable to convert search limit to int - set to default %d", cfg.DefaultLimit))
 		query.Set("limit", strconv.Itoa(cfg.DefaultLimit))
@@ -63,15 +69,27 @@ func getLimitFromURLQuery(ctx context.Context, cfg *config.Config, query url.Val
 }
 
 func getPageFromURLQuery(ctx context.Context, cfg *config.Config, query url.Values) int {
-	page, err := strconv.Atoi(query.Get("page"))
+	pageParam := query.Get("page")
+
+	if pageParam == "" {
+		return cfg.DefaultPage
+	}
+
+	page, err := strconv.Atoi(pageParam)
 	if err != nil {
-		log.Info(ctx, fmt.Sprintf("unable to convert search page to int - set to default %d", cfg.DefaultPage))
+		log.Info(ctx, "unable to convert search page to int - set to default", log.Data{
+			"default": cfg.DefaultPage,
+			"page":    page,
+		})
 		query.Set("page", strconv.Itoa(cfg.DefaultPage))
 		page = cfg.DefaultPage
 	}
 
 	if page < 1 {
-		log.Info(ctx, fmt.Sprintf("page number is less than default - default to page %d", cfg.DefaultPage))
+		log.Info(ctx, "page number is less than default - set to default", log.Data{
+			"default": cfg.DefaultPage,
+			"page":    page,
+		})
 		query.Set("page", strconv.Itoa(cfg.DefaultPage))
 		page = cfg.DefaultPage
 	}

--- a/data/pagination_test.go
+++ b/data/pagination_test.go
@@ -148,7 +148,7 @@ func TestUnitGetLimitFromURLQuerySuccess(t *testing.T) {
 		Convey("When getLimitFromURLQuery is called", func() {
 			limit := getLimitFromURLQuery(ctx, cfg, query)
 
-			Convey("Then successfully return the DefaultLimit as integer", func() {
+			Convey("Then successfully return the DefaultMaximumLimit as integer", func() {
 				So(limit, ShouldEqual, cfg.DefaultMaximumLimit)
 			})
 

--- a/data/pagination_test.go
+++ b/data/pagination_test.go
@@ -157,6 +157,21 @@ func TestUnitGetLimitFromURLQuerySuccess(t *testing.T) {
 			})
 		})
 	})
+
+	Convey("Given no limit specified", t, func() {
+		cfg, err := config.Get()
+		So(err, ShouldBeNil)
+
+		query := url.Values{}
+
+		Convey("When getLimitFromURLQuery is called", func() {
+			limit := getLimitFromURLQuery(ctx, cfg, query)
+
+			Convey("Then successfully return the DefaultLimit as integer", func() {
+				So(limit, ShouldEqual, cfg.DefaultLimit)
+			})
+		})
+	})
 }
 
 func TestUnitGetPageFromURLQuerySuccess(t *testing.T) {

--- a/data/sort.go
+++ b/data/sort.go
@@ -51,7 +51,12 @@ func reviewSort(ctx context.Context, urlQuery url.Values, validatedQueryParams *
 	sort, found := sortOptions[sortQuery]
 
 	if !found {
-		log.Warn(ctx, "sort chosen not available in sort options - default to sort "+defaultSort)
+		if sortQuery != "" {
+			log.Warn(ctx, "sort chosen not available in sort options - using default sort", log.Data{
+				"default": defaultSort,
+			})
+		}
+
 		sort.Query = defaultSort
 		sort.LocaliseKeyName = sortOptions[defaultSort].LocaliseKeyName
 	}


### PR DESCRIPTION
### What

Removed more excess logging statements - will remove around 420K logs per day. 

### How to review

Port forward to web api router, make a generic request (/search?q=test) and ensure these logs don't appear. Then make requests with strange options (limit=pear, page=grapefruit, sort=rollercoasters) and ensure they do appear.  

### Who can review

Not me. 