### PR TITLE
Fix/remove SearchNoIndexEnabled

### DIFF
--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -42,7 +42,6 @@ func CreateSearchPage(cfg *config.Config, req *http.Request, basePage coreModel.
 	page.Pagination.CurrentPage = validatedQueryParams.CurrentPage
 	page.ServiceMessage = homepageResponse.ServiceMessage
 	page.EmergencyBanner = mapEmergencyBanner(homepageResponse)
-	page.SearchNoIndexEnabled = true
 	page.FeatureFlags.IsPublishing = cfg.IsPublishing
 	if navigationContent != nil {
 		page.NavigationContent = mapNavigationContent(*navigationContent)
@@ -234,7 +233,6 @@ func mapDataPage(page *model.SearchPage, respC *searchModels.SearchResponse, lan
 	page.Pagination.CurrentPage = validatedQueryParams.CurrentPage
 	page.ServiceMessage = homepageResponse.ServiceMessage
 	page.EmergencyBanner = mapEmergencyBanner(homepageResponse)
-	page.SearchNoIndexEnabled = true
 	page.FeatureFlags.IsPublishing = cfg.IsPublishing
 	if navigationContent != nil {
 		page.NavigationContent = mapNavigationContent(*navigationContent)
@@ -267,7 +265,6 @@ func CreateDataFinderPage(cfg *config.Config, req *http.Request, basePage coreMo
 	page.Pagination.CurrentPage = validatedQueryParams.CurrentPage
 	page.ServiceMessage = homepageResponse.ServiceMessage
 	page.EmergencyBanner = mapEmergencyBanner(homepageResponse)
-	page.SearchNoIndexEnabled = true
 	if navigationContent != nil {
 		page.NavigationContent = mapNavigationContent(*navigationContent)
 	}

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -42,6 +42,7 @@ func CreateSearchPage(cfg *config.Config, req *http.Request, basePage coreModel.
 	page.Pagination.CurrentPage = validatedQueryParams.CurrentPage
 	page.ServiceMessage = homepageResponse.ServiceMessage
 	page.EmergencyBanner = mapEmergencyBanner(homepageResponse)
+	page.SearchNoIndexEnabled = true
 	page.FeatureFlags.IsPublishing = cfg.IsPublishing
 	if navigationContent != nil {
 		page.NavigationContent = mapNavigationContent(*navigationContent)

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -151,8 +151,6 @@ func TestUnitCreateSearchPage(t *testing.T) {
 				So(sp.EmergencyBanner.Description, ShouldEqual, respH.EmergencyBanner.Description)
 				So(sp.EmergencyBanner.URI, ShouldEqual, respH.EmergencyBanner.URI)
 				So(sp.EmergencyBanner.LinkText, ShouldEqual, respH.EmergencyBanner.LinkText)
-
-				So(sp.SearchNoIndexEnabled, ShouldEqual, true)
 			})
 		})
 	})
@@ -265,8 +263,6 @@ func TestUnitFindDatasetPage(t *testing.T) {
 				So(sp.EmergencyBanner.Description, ShouldEqual, respH.EmergencyBanner.Description)
 				So(sp.EmergencyBanner.URI, ShouldEqual, respH.EmergencyBanner.URI)
 				So(sp.EmergencyBanner.LinkText, ShouldEqual, respH.EmergencyBanner.LinkText)
-
-				So(sp.SearchNoIndexEnabled, ShouldEqual, true)
 			})
 		})
 	})
@@ -388,8 +384,6 @@ func TestCreateDataAggregationPage(t *testing.T) {
 				So(sp.EmergencyBanner.Description, ShouldEqual, respH.EmergencyBanner.Description)
 				So(sp.EmergencyBanner.URI, ShouldEqual, respH.EmergencyBanner.URI)
 				So(sp.EmergencyBanner.LinkText, ShouldEqual, respH.EmergencyBanner.LinkText)
-				// no index setting
-				So(sp.SearchNoIndexEnabled, ShouldEqual, true)
 			})
 
 			Convey("Then successfully map validation errors correctly to a page model", func() {

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -151,6 +151,8 @@ func TestUnitCreateSearchPage(t *testing.T) {
 				So(sp.EmergencyBanner.Description, ShouldEqual, respH.EmergencyBanner.Description)
 				So(sp.EmergencyBanner.URI, ShouldEqual, respH.EmergencyBanner.URI)
 				So(sp.EmergencyBanner.LinkText, ShouldEqual, respH.EmergencyBanner.LinkText)
+
+				So(sp.SearchNoIndexEnabled, ShouldEqual, true)
 			})
 		})
 	})


### PR DESCRIPTION
### What
This stops the aggregation pages using a `noindex` metatag.

_Before_
![Pasted Graphic 1](https://github.com/ONSdigital/dp-frontend-search-controller/assets/110108574/85073eea-827a-40c9-9cd9-ae0e8a9fa431)

_After_
![Pasted Graphic 2](https://github.com/ONSdigital/dp-frontend-search-controller/assets/110108574/802bcffb-f511-46a4-8b27-109a14d12d67)

### How to review
Pull this branch
Run dp-frontend-search-controller using make debug ENABLE_REWORKED_DATA_AGGREGATION_PAGES=true
Port forward the api router to sandbox dp ssh sandbox web 1 -p 23200:localhost:10800

Head to these and open the console (F12): 

- http://localhost:25000/datalist
- http://localhost:25000/timeseriestool

Check if any of them have a `noindex` metatag

Ensure `/search` still has one
- http://localhost:25000/search

### Who can review
Anyone