### PR TITLE
Fix/design on aggregated pages

### DIFF
--- a/assets/templates/data-aggregation-page.tmpl
+++ b/assets/templates/data-aggregation-page.tmpl
@@ -18,29 +18,44 @@
       novalidate
     >
       <div class="ons-grid__col ons-col-4@m">
-        <section class="search__filter" role="contentinfo" aria-label="{{ localise "SearchFiltering" $lang 4 }}" id="search-filter">
+        <section
+          class="search__filter"
+          role="contentinfo"
+          aria-label="{{ localise "SearchFiltering" $lang 4 }}"
+          id="search-filter"
+        >
           <div class="search__filter__heading">
             <h3 class="font-size--18">
               {{ localise "Filter" $lang 4 }} {{ localise .Data.TermLocalKey $lang 4 }}
             </h3>
-            <a href="?{{ if .Data.Query }}q={{ .Data.Query}}{{end}}" id="clear-search" class="float-right font-size--18">{{ localise "ClearAll" $lang 1 }}</a>
+            <a
+              href="?{{ if .Data.Query }}q={{ .Data.Query}}{{end}}"
+              id="clear-search"
+              class="float-right font-size--18"
+            >{{ localise "ClearAll" $lang 1 }}</a>
           </div>
-          <div class="search__filter__content">
+          <div class="search__filter__content ons-u-bb">
             {{ template "partials/data-aggregation-filters" . }}
           </div>
           <button
             type="submit"
             class="ons-btn ons-u-mt-l ons-u-mb-l text-wrap"
-            >
+          >
             <span class="ons-btn__inner">{{ localise "ApplyFilters" .Language 1 }}</span>
           </button>
-          <div class="search__filter__content hide--sm">
+          <div class="search__filter__content hide--sm ons-u-mt-l ons-u-mr-s">
             {{ template "partials/archived-release-message" . }}
           </div>
         </section>
       </div>
-      <div class="ons-grid__col ons-col-8@m" aria-live="polite">
-        <section role="contentinfo" aria-label="{{ localise "SearchResults" $lang 1 }}">
+      <div
+        class="ons-grid__col ons-col-8@m"
+        aria-live="polite"
+      >
+        <section
+          role="contentinfo"
+          aria-label="{{ localise "SearchResults" $lang 1 }}"
+        >
           <div class="search__count">
             {{ template "partials/count" . }}
           </div>
@@ -50,26 +65,31 @@
                 {{ template "partials/sort" . }}
               </div>
               {{ if .RSSLink }}
-                <div class="ons-grid__col ons-u-wa--@l ons-u-pt-xxs@l">
-                  {{ template "partials/rss-feed" . }}
-                </div>
+              <div class="ons-grid__col ons-u-wa--@l ons-u-pt-xxs@l">
+                {{ template "partials/rss-feed" . }}
+              </div>
               {{ end }}
             </div>
           </div>
           <div class="search__filter__mobile-filter-toggle hide">
-              <button id="filter-results" type="button" class="ons-btn ons-btn--secondary" aria-controls="search-filter">
-                <span class="ons-btn__inner">{{ localise "FilterResults" $lang 4 }}</span>
-              </button>
+            <button
+              id="filter-results"
+              type="button"
+              class="ons-btn ons-btn--secondary"
+              aria-controls="search-filter"
+            >
+              <span class="ons-btn__inner">{{ localise "FilterResults" $lang 4 }}</span>
+            </button>
           </div>
-          
+
           <div class="search__results ons-u-bt ons-u-mt-no">
             {{ template "partials/data-aggregation-results" . }}
           </div>
-        
+
           {{ if gt .Data.Response.Count 0 }}
-            <div class="search__pagination">
-              {{ template "partials/search-pagination" . }}
-            </div>
+          <div class="search__pagination">
+            {{ template "partials/search-pagination" . }}
+          </div>
           {{ end }}
         </section>
       </div>

--- a/assets/templates/partials/archived-release-message.tmpl
+++ b/assets/templates/partials/archived-release-message.tmpl
@@ -1,29 +1,15 @@
-{{ $lang := .Language }}
-
-<div id="earlier-release-accordion" class="ons-accordion">
-    <details class="ons-collapsible ons-js-collapsible ons-collapsible--accordion" data-group="accordion" data-btn-close="Hide this" data-open="true">
-        <summary class="ons-collapsible__heading ons-js-collapsible-heading">
-            <h2 class="ons-collapsible__title">
-                <legend class="block">
-                    {{ localise "EarlierReleases" $lang 1 }}
-                </legend>
-            </h2>
-            <span class="ons-collapsible__icon">
-                {{ template "icons/chevron-right" }}
-            </span>
-        </summary>
-        <fieldset class="ons-collapsible__content ons-js-details-content ons-u-mb-s">
-            <legend class="ons-u-vh">{{ localise "SelectContentType" $lang 1 }}</legend>
-            <div class="tiles__item tiles__item--nav-type flush-col print--hide">
-                <div class="tiles__content tiles__content--nav">
-                    <p>
-                        {{ localise "NationalArchives" $lang 1 | safeHTML}}
-                    </p>
-                    <p>
-                        {{ localise "HistoricalDataNote" $lang 1 | safeHTML}}
-                    </p>
-                </div>
-            </div>
-        </fieldset>
-    </details>
+<div id="earlier-release-accordion">
+    <h2 class="ons-u-fs-m">
+        {{- localise "EarlierReleases" .Language 1 -}}
+    </h2>
+    <div class="tiles__item tiles__item--nav-type flush-col print--hide">
+        <div class="tiles__content tiles__content--nav">
+            <p>
+                {{- localise "NationalArchives" .Language 1 | safeHTML -}}
+            </p>
+            <p>
+                {{- localise "HistoricalDataNote" .Language 1 | safeHTML -}}
+            </p>
+        </div>
+    </div>
 </div>

--- a/assets/templates/time-series-tool.tmpl
+++ b/assets/templates/time-series-tool.tmpl
@@ -25,7 +25,7 @@
             <a href="?{{ if .Data.Query }}q={{ .Data.Query}}{{end}}" id="clear-search" class="float-right font-size--18">{{ localise "ClearAll" $lang 1 }}</a>
           </div>
           
-          <div class="search__filter__content">
+          <div class="search__filter__content ons-u-bb">
             {{ template "partials/data-aggregation-filters" . }}
           </div>
           <button
@@ -34,7 +34,7 @@
             >
             <span class="ons-btn__inner">{{ localise "ApplyFilters" .Language 1 }}</span>
           </button>
-          <div class="search__filter__content hide--sm">
+          <div class="search__filter__content hide--sm ons-u-mt-l ons-u-mr-s">
             {{ template "partials/archived-release-message" . }}
           </div>
         </section>


### PR DESCRIPTION
### What

✅ [Fixing design on aggregated data pages](https://jira.ons.gov.uk/browse/DIS-955) where the 'need an earlier release' section had been placed in to a collapsible

### How to review

Sense check
Image review
__Optionally__ pull this branch and run `make debug ENABLE_AGGREGATION_PAGES=true`, `npm run dev` on `dp-design-system` and port forward to the api router in sandbox - `dp ssh sandbox web 1 -p 23200:localhost:10800` and view the different aggregated data page types found in `routes.go`

#### Images

<img width="445" alt="timeseries example" src="https://github.com/ONSdigital/dp-frontend-search-controller/assets/19624419/3a4cfbe5-f0c8-456f-b801-b2232d5ccb2e">
<img width="445" alt="section with search above" src="https://github.com/ONSdigital/dp-frontend-search-controller/assets/19624419/8b8dc698-8866-4cd3-9b78-462c3b42c43a">
<img width="506" alt="section with date fieldset above" src="https://github.com/ONSdigital/dp-frontend-search-controller/assets/19624419/b749f57e-24dd-4bfb-9153-ff340851bce2">

### Who can review

Frontend dev
