### PR TITLE
Remove dateFormat from dataset metadata

### DIFF
--- a/assets/templates/partials/data-aggregation-results.tmpl
+++ b/assets/templates/partials/data-aggregation-results.tmpl
@@ -80,13 +80,13 @@
                     {{ if .Description.CDID }}
                     <li class="ons-document-list__item-attribute">
                         <span class="ons-u-fw-b">{{ localise "SeriesID" $lang 1 }}:</span>
-                        <span> {{ dateFormat .Description.CDID }}</span>
+                        <span> {{ .Description.CDID }}</span>
                     </li>
                     {{ end }}
                     {{ if .Description.DatasetID }}
                     <li class="ons-document-list__item-attribute">
                         <span class="ons-u-fw-b">{{ localise "DatasetID" $lang 1 }}:</span>
-                        <span> {{ dateFormat .Description.DatasetID }}</span>
+                        <span> {{ .Description.DatasetID }}</span>
                     </li>
                     {{ end }}
                 </ul>


### PR DESCRIPTION
### What

Remove erroneous dateFormat from CDID / Series ID in timeseriestool

### How to review

Check looks ok, tests pass. 

Optionally:

- port forward to api router
- run with EnableAggregationPages switched to true
- visit /timeseriestool
- see that 'failed to parse time' no longer appears in logs. 

### Who can review

Not me. 