### PR TITLE
Bump render version to avoid cached version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/ONSdigital/dp-healthcheck v1.6.3
 	github.com/ONSdigital/dp-net/v2 v2.11.2
 	github.com/ONSdigital/dp-otel-go v0.0.7
-	github.com/ONSdigital/dp-renderer/v2 v2.13.0
+	github.com/ONSdigital/dp-renderer/v2 v2.13.1
 	github.com/ONSdigital/dp-search-api v1.43.1
 	github.com/ONSdigital/dp-topic-api v0.23.0
 	github.com/ONSdigital/log.go/v2 v2.4.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/ONSdigital/dp-net/v2 v2.11.2 h1:S5WfcXHva1V8ZkVLS7ZhsvQjf3PPCkCM++NdG
 github.com/ONSdigital/dp-net/v2 v2.11.2/go.mod h1:yZ0lIzM4WfIr6Ujl1lpkCsPHay0n/VQfZJUZjlYB8MY=
 github.com/ONSdigital/dp-otel-go v0.0.7 h1:O4F+7CTYbPeY9kF550RC8x8WJtILBZfcHL/38EdaWZU=
 github.com/ONSdigital/dp-otel-go v0.0.7/go.mod h1:3dIbySH98wXfHOx/zWLBPv4W/QsBiMarSfKavG2xTOw=
-github.com/ONSdigital/dp-renderer/v2 v2.13.0 h1:uen4FW63SnkvvxwtUl8gmKDf+azMqlzdgSPFnGqFG6M=
-github.com/ONSdigital/dp-renderer/v2 v2.13.0/go.mod h1:ZtSTy8nQ+ewawVFAoPEIEn1u+JszHZgl4ir4hhfasIg=
+github.com/ONSdigital/dp-renderer/v2 v2.13.1 h1:n59cxcIiXyQO6OkuuZOqc24EbPljZOrgKg1t9+kS8Ns=
+github.com/ONSdigital/dp-renderer/v2 v2.13.1/go.mod h1:ZtSTy8nQ+ewawVFAoPEIEn1u+JszHZgl4ir4hhfasIg=
 github.com/ONSdigital/dp-search-api v1.43.1 h1:f2eVG5YVF1vV5WQM5ntQNKU3iS4VMoCG3fWpLS9wPgc=
 github.com/ONSdigital/dp-search-api v1.43.1/go.mod h1:JIt/Axuu5J/gbRhlnIMdJFCKbPiqDGqyPonCiMjchBE=
 github.com/ONSdigital/dp-search-scrubber-api v0.4.1 h1:aj0g1hUZENS9PB+BHhasCIvuE9i+/OSgL9AqCmed5dw=


### PR DESCRIPTION
### What

Bumped to 1.13.1 to avoid a cached version of dp-renderer that doesn't have the changes. 

### How to review

Check looks ok. 

### Who can review

Not me. 