### PR TITLE
Fix aggregated pages in publishing mode

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -313,9 +313,10 @@ func readDataAggregation(w http.ResponseWriter, req *http.Request, cfg *config.C
 	options.Query = searchQuery
 
 	options.Headers = http.Header{
-		searchSDK.FlorenceToken: {Bearer + accessToken},
-		searchSDK.CollectionID:  {collectionID},
+		searchSDK.CollectionID: {collectionID},
 	}
+
+	setFlorenceTokenHeader(options.Headers, accessToken)
 
 	go func() {
 		defer wg.Done()
@@ -468,9 +469,10 @@ func readDataAggregationWithTopics(w http.ResponseWriter, req *http.Request, cfg
 	options.Query = searchQuery
 
 	options.Headers = http.Header{
-		searchSDK.FlorenceToken: {Bearer + accessToken},
-		searchSDK.CollectionID:  {collectionID},
+		searchSDK.CollectionID: {collectionID},
 	}
+
+	setFlorenceTokenHeader(options.Headers, accessToken)
 
 	go func() {
 		defer wg.Done()
@@ -792,9 +794,10 @@ func createRSSFeed(ctx context.Context, w http.ResponseWriter, r *http.Request, 
 	options.Query = data.GetDataAggregationQuery(validatedParams, template)
 
 	options.Headers = http.Header{
-		searchSDK.FlorenceToken: {Bearer + accessToken},
-		searchSDK.CollectionID:  {collectionID},
+		searchSDK.CollectionID: {collectionID},
 	}
+
+	setFlorenceTokenHeader(options.Headers, accessToken)
 
 	searchResponse, respErr := api.GetSearch(ctx, options)
 	if respErr != nil {


### PR DESCRIPTION
### What

Fix agg pages in publishing mode when logged in to florence.

### How to review

Check consistency with approach for main search (which works). 

To test:

Populate local search index, run florence in SecAuth mode (`SharedConfig.EnableNewSignIn`) and connect to sandbox api router for auth / search api / zebedee. 

Login to florence (to get auth cookies) and then access aggregated page routes (/alladhocs, /economy/publications). Requires `EnableTopicAggregationPages` and `EnableAggregationPages` to be switched on. 


### Who can review

Not me. 