### PR TITLE
Add parent content type setter func

### DIFF
--- a/data/query.go
+++ b/data/query.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ONSdigital/dp-frontend-search-controller/cache"
 	"github.com/ONSdigital/dp-frontend-search-controller/config"
 	"github.com/ONSdigital/log.go/v2/log"
+	"github.com/davecgh/go-spew/spew"
 
 	core "github.com/ONSdigital/dp-renderer/v2/model"
 )
@@ -163,7 +164,7 @@ func ReviewPreviousReleasesQueryWithParams(ctx context.Context, cfg *config.Conf
 	paginationErr := reviewPagination(ctx, cfg, urlQuery, &sp)
 	validationErrs = handleValidationError(ctx, paginationErr, "unable to review pagination for previous releases", PaginationErr, validationErrs)
 	reviewSort(ctx, urlQuery, &sp, cfg.DefaultPreviousReleasesSort)
-
+	spew.Dump(sp)
 	return sp, validationErrs
 }
 
@@ -499,4 +500,18 @@ func createSearchControllerQuery(validatedQueryParams SearchURLParams) url.Value
 		"limit":            []string{strconv.Itoa(validatedQueryParams.Limit)},
 		"page":             []string{strconv.Itoa(validatedQueryParams.CurrentPage)},
 	}
+}
+
+// SetParentTypeOnSearchAPIQuery sets the parent type (e.g. if this is previous releases for a bulletin) on the search API query
+func SetParentTypeOnSearchAPIQuery(validatedQueryParams SearchURLParams, parentType string) url.Values {
+	apiQuery := createSearchAPIQuery(validatedQueryParams)
+
+	if apiQuery.Get("content_type") == "" {
+		apiQuery.Set("content_type", parentType)
+	} else {
+		updateQueryWithAPIFilters(apiQuery)
+	}
+
+	spew.Dump(apiQuery)
+	return apiQuery
 }

--- a/data/query.go
+++ b/data/query.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ONSdigital/dp-frontend-search-controller/cache"
 	"github.com/ONSdigital/dp-frontend-search-controller/config"
 	"github.com/ONSdigital/log.go/v2/log"
-	"github.com/davecgh/go-spew/spew"
 
 	core "github.com/ONSdigital/dp-renderer/v2/model"
 )
@@ -164,7 +163,6 @@ func ReviewPreviousReleasesQueryWithParams(ctx context.Context, cfg *config.Conf
 	paginationErr := reviewPagination(ctx, cfg, urlQuery, &sp)
 	validationErrs = handleValidationError(ctx, paginationErr, "unable to review pagination for previous releases", PaginationErr, validationErrs)
 	reviewSort(ctx, urlQuery, &sp, cfg.DefaultPreviousReleasesSort)
-	spew.Dump(sp)
 	return sp, validationErrs
 }
 
@@ -512,6 +510,5 @@ func SetParentTypeOnSearchAPIQuery(validatedQueryParams SearchURLParams, parentT
 		updateQueryWithAPIFilters(apiQuery)
 	}
 
-	spew.Dump(apiQuery)
 	return apiQuery
 }

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -428,7 +428,7 @@ func readPreviousReleases(w http.ResponseWriter, req *http.Request, cfg *config.
 
 	// counter used to keep track of the number of concurrent API calls
 	var counter = 3
-	searchQuery := data.GetDataAggregationQuery(validatedQueryParams, template)
+	searchQuery := data.SetParentTypeOnSearchAPIQuery(validatedQueryParams, pageData.Type)
 
 	var (
 		homepageResp zebedeeCli.HomepageContent


### PR DESCRIPTION
### What

Set the parent page data type on the API query to fix return compendia and compendia chapters in `/previousreleases` page

<img width="1065" alt="image" src="https://github.com/user-attachments/assets/c216b33d-b60d-45bc-b0de-14a8ab0b351c">


### Who can review

Anyone
