### PR TITLE
Feature/known characters to search whitelist

### DIFF
--- a/data/string.go
+++ b/data/string.go
@@ -15,6 +15,9 @@ const minQueryLength = 3
 
 var regexString = strings.Repeat(`\S\s*`, minQueryLength)
 
+// contains the special characters that are allowed in query validation
+const AllowedSpecialCharacters = "–‘’"
+
 // reviewQueryString performs basic checks on the string entered by the user
 func reviewQueryString(ctx context.Context, urlQuery url.Values) error {
 	q := urlQuery.Get("q")
@@ -50,7 +53,7 @@ func checkForNonSpaceCharacters(ctx context.Context, queryString string) error {
 }
 
 func checkForSpecialCharacters(ctx context.Context, str string) error {
-	re := regexp.MustCompile("[^[:ascii:]–‘’]")
+	re := regexp.MustCompile(fmt.Sprintf("[^[:ascii:]%s]", regexp.QuoteMeta(AllowedSpecialCharacters)))
 
 	match := re.MatchString(str)
 

--- a/data/string.go
+++ b/data/string.go
@@ -50,7 +50,7 @@ func checkForNonSpaceCharacters(ctx context.Context, queryString string) error {
 }
 
 func checkForSpecialCharacters(ctx context.Context, str string) error {
-	re := regexp.MustCompile("[[:^ascii:]&&[^–‘’]]")
+	re := regexp.MustCompile("[^[:ascii:]–‘’]")
 
 	match := re.MatchString(str)
 

--- a/data/string.go
+++ b/data/string.go
@@ -50,7 +50,7 @@ func checkForNonSpaceCharacters(ctx context.Context, queryString string) error {
 }
 
 func checkForSpecialCharacters(ctx context.Context, str string) error {
-	re := regexp.MustCompile("[[:^ascii:]]")
+	re := regexp.MustCompile("[[:^ascii:]&&[^–‘’]]")
 
 	match := re.MatchString(str)
 


### PR DESCRIPTION
### What

This [adds](https://jira.ons.gov.uk/browse/DIS-1810) some non-ascii characters to whitelist in search query validation.
**Characters**
- en hyphen/dash (windows ALT 0150) –
- opening single quote (windown ALT 0145) ‘
- closing single quote (windows ALT 0146) ’

### How to review

Run search controller
_You'll also need [this](https://github.com/ONSdigital/dp-search-api/pull/297) branch of the search api_
http://localhost:25000/search?q=National+life+tables+–+life+expectancy
http://localhost:25000/search?q=UK+residents‘+visits+abroad

### Who can review

Anyone
