### PR TITLE
Fix/search sort dropdown

### DIFF
--- a/assets/templates/data-aggregation-page.tmpl
+++ b/assets/templates/data-aggregation-page.tmpl
@@ -59,7 +59,7 @@
           <div class="search__count">
             {{ template "partials/count" . }}
           </div>
-          <div class="ons-grid ons-u-mt-s">
+          <div class="ons-grid ons-u-mt-s ons-u-mb-s">
             <div class="ons-pl-grid ons-grid--flex@l ons-grid--between@l ">
               <div class="ons-grid__col ons-u-wa--@l">
                 {{ template "partials/sort" . }}

--- a/assets/templates/partials/filter.tmpl
+++ b/assets/templates/partials/filter.tmpl
@@ -10,10 +10,8 @@
 
 
 <div id="accordion" class="ons-accordion">
-
+    <input type="hidden" name="q" value="{{ $query }}">
     {{ if $topicFilters }}
-        <input type="hidden" name="q" value="{{ $query }}">
-        <input type="hidden" name="sort" value="{{$sort}}">
         <details class="ons-collapsible ons-js-collapsible ons-collapsible--accordion" data-group="accordion" data-btn-close="Hide this" data-open="true">
             <summary class="ons-collapsible__heading ons-js-collapsible-heading">
                 <h2 class="ons-collapsible__title">
@@ -77,7 +75,6 @@
     {{ end }} 
 
     {{ if $filters }}
-        <input type="hidden" name="q" value="{{ $query }}">
         <details class="ons-collapsible ons-js-collapsible ons-collapsible--accordion" data-group="accordion" data-btn-close="Hide this" data-open="true">
             <summary class="ons-collapsible__heading ons-js-collapsible-heading">
                 <h2 class="ons-collapsible__title">

--- a/assets/templates/partials/filter.tmpl
+++ b/assets/templates/partials/filter.tmpl
@@ -25,7 +25,7 @@
                     {{ template "icons/chevron-right" }}
                 </span>
             </summary>
-            <fieldset class="ons-fieldset">
+            <fieldset class="ons-fieldset ons-u-mb-s">
                 <legend class="ons-u-vh">{{ localise "CensusTopic" $lang 1 }}</legend>
                     {{ range $index, $topicFilter := $topicFilters }}
                         <div class="ons-checkboxes__items">

--- a/assets/templates/partials/filter.tmpl
+++ b/assets/templates/partials/filter.tmpl
@@ -12,7 +12,6 @@
 <div id="accordion" class="ons-accordion">
 
     {{ if $topicFilters }}
-    <form id="topicsFilterForm" method="get" class="js-auto-submit__form">
         <input type="hidden" name="q" value="{{ $query }}">
         <input type="hidden" name="sort" value="{{$sort}}">
         <details class="ons-collapsible ons-js-collapsible ons-collapsible--accordion" data-group="accordion" data-btn-close="Hide this" data-open="true">
@@ -74,133 +73,112 @@
                         </div>
                     {{ end }}
             </fieldset>
-            <noscript>
-                <button type="submit" class="ons-btn ons-btn--primary margin-top-sm--2 margin-top-md--2 js-submit-button">
-                        <span class="ons-btn__inner"><span class="ons-btn__text">{{ localise "Filter" $lang 4}}</span></span>
-                </button>
-            </noscript>
         </details>
-    </form>
     {{ end }} 
 
     {{ if $filters }}
-    <form id="filterForm" method="get" class="js-auto-submit__form">
-            <details class="ons-collapsible ons-js-collapsible ons-collapsible--accordion" data-group="accordion" data-btn-close="Hide this" data-open="true">
-                <summary class="ons-collapsible__heading ons-js-collapsible-heading">
-                    <h2 class="ons-collapsible__title">
-                        <legend class="block">
-                            {{ localise "ContentType" $lang 1 }}
-                        </legend>
-                    </h2>
-                    <span class="ons-collapsible__icon">
-                        {{ template "icons/chevron-right" }}
-                    </span>
-                </summary>
-                <fieldset class="ons-collapsible__content ons-js-details-content ons-u-mb-s">
-                    <legend class="ons-u-vh">{{ localise "SelectContentType" $lang 1 }}</legend>
-                        {{ range $index, $topFilter := $filters}}
-                            <div class="ons-checkboxes__items">
-                                <span class="ons-checkboxes__item ons-checkboxes__item--no-border">
-                                    <span class="ons-checkbox ons-checkbox--no-border content-type-filter">
-                                        <input type="checkbox" id="group-{{ $index }}"
-                                            class="ons-checkbox__input ons-js-checkbox"
+        <input type="hidden" name="q" value="{{ $query }}">
+        <details class="ons-collapsible ons-js-collapsible ons-collapsible--accordion" data-group="accordion" data-btn-close="Hide this" data-open="true">
+            <summary class="ons-collapsible__heading ons-js-collapsible-heading">
+                <h2 class="ons-collapsible__title">
+                    <legend class="block">
+                        {{ localise "ContentType" $lang 1 }}
+                    </legend>
+                </h2>
+                <span class="ons-collapsible__icon">
+                    {{ template "icons/chevron-right" }}
+                </span>
+            </summary>
+            <fieldset class="ons-collapsible__content ons-js-details-content ons-u-mb-s">
+                <legend class="ons-u-vh">{{ localise "SelectContentType" $lang 1 }}</legend>
+                    {{ range $index, $topFilter := $filters}}
+                        <div class="ons-checkboxes__items">
+                            <span class="ons-checkboxes__item ons-checkboxes__item--no-border">
+                                <span class="ons-checkbox ons-checkbox--no-border content-type-filter">
+                                    <input type="checkbox" id="group-{{ $index }}"
+                                        class="ons-checkbox__input ons-js-checkbox"
                                             value="{{ print $topFilter.FilterKey }}" categoryChildren="{{ print $topFilter.FilterKey }}" aria-controls="group-{{ $index }}-other-wrap"
-                                            data-gtm-label="{{ $topFilter.LocaliseKeyName }}"
-                                            {{ if $topFilter.IsChecked }}
-                                                checked
-                                            {{ end }}
-                                        >
-                                        <label class="ons-checkbox__label" for="group-{{ $index }}" id="group-{{ $index }}-label">
-                                            {{ localise $topFilter.LocaliseKeyName $lang 4 }} ({{ $topFilter.NumberOfResults }})
-                                        </label>
-                                        <span class="ons-checkbox__other" id="group-{{ $index }}-other-wrap">
-                                            <fieldset class="ons-fieldset ons-js-other-fieldset">
-                                                <legend class="ons-u-vh">{{ localise "Select" $lang 1 }}{{ localise $topFilter.LocaliseKeyName $lang 4 }}</legend>
-                                                    {{ range $index, $childFilter := $topFilter.Types }}
-                                                        {{ $id := index $childFilter.FilterKey 0 }}
-                                                        <div class="ons-checkboxes__items">
-                                                            <span class="ons-checkboxes__item ons-checkboxes__item--no-border">
-                                                                <span class="ons-checkbox ons-checkbox--no-border child-filter">
-                                                                    <input id="{{ $id }}"
-                                                                        class="ons-checkbox__input ons-js-checkbox"
-                                                                        type="checkbox" name="filter"
-                                                                        {{ if $childFilter.IsChecked }}checked{{ end }}
-                                                                        data-gtm-label="{{ $childFilter.LocaliseKeyName }}"
-                                                                        value="{{ $id }}"
-                                                                    >
-                                                                    <label class="ons-checkbox__label" for="{{ $id }}"
-                                                                        id="{{ $id }}-label">
-                                                                        {{ localise $childFilter.LocaliseKeyName $lang 4 }} ({{ $childFilter.NumberOfResults }})
-                                                                    </label>
-                                                                </span>
+                                        data-gtm-label="{{ $topFilter.LocaliseKeyName }}"
+                                        {{ if $topFilter.IsChecked }}
+                                            checked
+                                        {{ end }}
+                                    >
+                                    <label class="ons-checkbox__label" for="group-{{ $index }}" id="group-{{ $index }}-label">
+                                        {{ localise $topFilter.LocaliseKeyName $lang 4 }} ({{ $topFilter.NumberOfResults }})
+                                    </label>
+                                    <span class="ons-checkbox__other" id="group-{{ $index }}-other-wrap">
+                                        <fieldset class="ons-fieldset ons-js-other-fieldset">
+                                            <legend class="ons-u-vh">{{ localise "Select" $lang 1 }}{{ localise $topFilter.LocaliseKeyName $lang 4 }}</legend>
+                                                {{ range $index, $childFilter := $topFilter.Types }}
+                                                    {{ $id := index $childFilter.FilterKey 0 }}
+                                                    <div class="ons-checkboxes__items">
+                                                        <span class="ons-checkboxes__item ons-checkboxes__item--no-border">
+                                                            <span class="ons-checkbox ons-checkbox--no-border child-filter">
+                                                                <input id="{{ $id }}"
+                                                                    class="ons-checkbox__input ons-js-checkbox"
+                                                                    type="checkbox" name="filter"
+                                                                    {{ if $childFilter.IsChecked }}checked{{ end }}
+                                                                    data-gtm-label="{{ $childFilter.LocaliseKeyName }}"
+                                                                    value="{{ $id }}"
+                                                                >
+                                                                <label class="ons-checkbox__label" for="{{ $id }}"
+                                                                    id="{{ $id }}-label">
+                                                                    {{ localise $childFilter.LocaliseKeyName $lang 4 }} ({{ $childFilter.NumberOfResults }})
+                                                                </label>
                                                             </span>
-                                                        </div>
-                                                    {{ end }}
-                                            </fieldset>
-                                        </span>
+                                                        </span>
+                                                    </div>
+                                                {{ end }}
+                                        </fieldset>
                                     </span>
                                 </span>
-                            </div>
-                        {{ end }}
-                </fieldset>
-                <noscript>
-                    <button type="submit"
-                            class="ons-btn ons-btn--primary margin-top-sm--2 margin-top-md--2 js-submit-button">
-                            <span class="ons-btn__inner"><span class="ons-btn__text">{{ localise "Filter" $lang 4}}</span></span>
-                    </button>
-                </noscript>
-            </details>
-    </form>
+                            </span>
+                        </div>
+                    {{ end }}
+            </fieldset>
+        </details>
     {{ end }}
 
     {{ if $censusFilters }}
     {{ $translationKey := "Topic" }}
     {{ $key := "census" }}
     {{ $value := $censusFilters }}
-    <form id="filterForm{{ $translationKey }}" method="get" class="js-auto-submit__form">
-            <details class="ons-collapsible ons-js-details ons-collapsible--accordion" data-group="accordion" data-btn-close="Hide this" data-open="true">
-                <summary class="ons-collapsible__heading ons-js-collapsible-heading">
-                    <h2 class="ons-collapsible__title">
-                        <legend class="block">
-                            {{ localise $translationKey $lang 4 }}
-                        </legend>
-                    </h2>
-                    <span class="ons-collapsible__icon">
-                        {{ template "icons/chevron-right" }}
-                    </span>
-                </summary>
-                <div class="ons-collapsible__content ons-js-details-content ons-u-mb-s">
-                    {{ range $index, $filter := $value }}
-                    {{ $id := $filter.Query }}
+        <details class="ons-collapsible ons-js-details ons-collapsible--accordion" data-group="accordion" data-btn-close="Hide this" data-open="true">
+            <summary class="ons-collapsible__heading ons-js-collapsible-heading">
+                <h2 class="ons-collapsible__title">
+                    <legend class="block">
+                        {{ localise $translationKey $lang 4 }}
+                    </legend>
+                </h2>
+                <span class="ons-collapsible__icon">
+                    {{ template "icons/chevron-right" }}
+                </span>
+            </summary>
+            <div class="ons-collapsible__content ons-js-details-content ons-u-mb-s">
+                {{ range $index, $filter := $value }}
+                {{ $id := $filter.Query }}
 
-                    <div class="ons-checkboxes__items">
-                        <span class="ons-checkboxes__item ons-checkboxes__item--no-border">
-                            <span class="ons-checkbox ons-checkbox--no-border {{ $key }}">
-                                <input type="checkbox" id="{{ $key }}-group-{{ $index }}"
-                                    class="ons-checkbox__input ons-js-checkbox"
-                                    name="{{ $key }}"
-                                    value="{{ $id }}"
-                                    data-gtm-label="{{ $id }}"
-                                    {{ if $filter.IsChecked }}
-                                        checked
-                                    {{ end }}
-                                >
-                                <label class="ons-checkbox__label" for="{{ $key }}-group-{{ $index }}" id="{{ $key }}-group-{{ $index }}-label">
-                                    {{ $filter.LocaliseKeyName }} ({{ $filter.NumberOfResults }})
-                                </label>
-                            </span>
+                <div class="ons-checkboxes__items">
+                    <span class="ons-checkboxes__item ons-checkboxes__item--no-border">
+                        <span class="ons-checkbox ons-checkbox--no-border {{ $key }}">
+                            <input type="checkbox" id="{{ $key }}-group-{{ $index }}"
+                                class="ons-checkbox__input ons-js-checkbox"
+                                name="{{ $key }}"
+                                value="{{ $id }}"
+                                data-gtm-label="{{ $id }}"
+                                {{ if $filter.IsChecked }}
+                                    checked
+                                {{ end }}
+                            >
+                            <label class="ons-checkbox__label" for="{{ $key }}-group-{{ $index }}" id="{{ $key }}-group-{{ $index }}-label">
+                                {{ $filter.LocaliseKeyName }} ({{ $filter.NumberOfResults }})
+                            </label>
                         </span>
-                    </div>         
-                    {{ end }}         
-                </div>
-            </details>
-        <noscript>
-            <button type="submit"
-                    class="ons-btn ons-btn--primary margin-top-sm--2 margin-top-md--2 js-submit-button">
-                    <span class="ons-btn__inner"><span class="ons-btn__text">{{ localise "Filter" $lang 4}}</span></span>
-            </button>
-        </noscript>
-    </form>
+                    </span>
+                </div>         
+                {{ end }}         
+            </div>
+        </details>
     {{ end }}
 
 
@@ -208,95 +186,80 @@
     {{ $translationKey := "PopulationTypes" }}
     {{ $key := "population-types" }}
     {{ $value := $population_types }}
-    <form id="filterForm{{ $translationKey }}" method="get" class="js-auto-submit__form">
-            <details class="ons-collapsible ons-js-details ons-collapsible--accordion" data-group="accordion" data-btn-close="Hide this" data-open="true">
-                <summary class="ons-collapsible__heading ons-js-collapsible-heading">
-                    <h2 class="ons-collapsible__title">
-                        <legend class="block">
-                            {{ localise $translationKey $lang 1 }}
-                        </legend>
-                    </h2>
-                    <span class="ons-collapsible__icon">
-                        {{ template "icons/chevron-right" }}
-                    </span>
-                </summary>
-                <div class="ons-collapsible__content ons-js-details-content ons-u-mb-s">
-                    {{ range $index, $filter := $value }}
-                    <div class="ons-checkboxes__items">
-                        <span class="ons-checkboxes__item ons-checkboxes__item--no-border">
-                            <span class="ons-checkbox ons-checkbox--no-border {{ $key }}">
-                                <input type="checkbox" id="{{ $key }}-group-{{ $index }}"
-                                    class="ons-checkbox__input ons-js-checkbox"
-                                    name="{{ $key }}"
-                                    value="{{ print $filter.Type }}"
-                                    data-gtm-label="{{ $filter.Type }}"
-                                    {{ if $filter.IsChecked }}
-                                        checked
-                                    {{ end }}
-                                >
-                                <label class="ons-checkbox__label" for="{{ $key }}-group-{{ $index }}" id="{{ $key }}-group-{{ $index }}-label">
-                                    {{ $filter.LocaliseKeyName }} ({{ $filter.Count }})
-                                </label>
-                            </span>
+        <details class="ons-collapsible ons-js-details ons-collapsible--accordion" data-group="accordion" data-btn-close="Hide this" data-open="true">
+            <summary class="ons-collapsible__heading ons-js-collapsible-heading">
+                <h2 class="ons-collapsible__title">
+                    <legend class="block">
+                        {{ localise $translationKey $lang 1 }}
+                    </legend>
+                </h2>
+                <span class="ons-collapsible__icon">
+                    {{ template "icons/chevron-right" }}
+                </span>
+            </summary>
+            <div class="ons-collapsible__content ons-js-details-content ons-u-mb-s">
+                {{ range $index, $filter := $value }}
+                <div class="ons-checkboxes__items">
+                    <span class="ons-checkboxes__item ons-checkboxes__item--no-border">
+                        <span class="ons-checkbox ons-checkbox--no-border {{ $key }}">
+                            <input type="checkbox" id="{{ $key }}-group-{{ $index }}"
+                                class="ons-checkbox__input ons-js-checkbox"
+                                name="{{ $key }}"
+                                value="{{ print $filter.Type }}"
+                                data-gtm-label="{{ $filter.Type }}"
+                                {{ if $filter.IsChecked }}
+                                    checked
+                                {{ end }}
+                            >
+                            <label class="ons-checkbox__label" for="{{ $key }}-group-{{ $index }}" id="{{ $key }}-group-{{ $index }}-label">
+                                {{ $filter.LocaliseKeyName }} ({{ $filter.Count }})
+                            </label>
                         </span>
-                    </div>
-                    {{ end }}
+                    </span>
                 </div>
-            </details>
-        <noscript>
-            <button type="submit"
-                    class="ons-btn ons-btn--primary margin-top-sm--2 margin-top-md--2 js-submit-button">
-                    <span class="ons-btn__inner"><span class="ons-btn__text">{{ localise "Filter" $lang 4}}</span></span>
-            </button>
-        </noscript>
+                {{ end }}
+            </div>
+        </details>
     </form>
     {{ end }}
     {{ if $dimensions }}
     {{ $key := "dimensions" }}
     {{ $translationKey := "Dimensions" }}
     {{ $value := $dimensions }}
-    <form id="filterForm{{ $translationKey }}" method="get" class="js-auto-submit__form">
-            <details class="ons-collapsible ons-js-details ons-collapsible--accordion" data-group="accordion" data-btn-close="Hide this" data-open="true">
-                <summary class="ons-collapsible__heading ons-js-collapsible-heading">
-                    <h2 class="ons-collapsible__title">
-                        <legend class="block">
-                            {{ localise $translationKey $lang 1 }}
-                        </legend>
-                    </h2>
-                    <span class="ons-collapsible__icon">
-                        {{ template "icons/chevron-right" }}
-                    </span>
-                </summary>
-                <div class="ons-collapsible__content ons-js-details-content ons-u-mb-s">
-                    {{ range $index, $filter := $value }}
-                    <div class="ons-checkboxes__items">
-                        <span class="ons-checkboxes__item ons-checkboxes__item--no-border">
-                            <span class="ons-checkbox ons-checkbox--no-border {{ $key }}">
-                                <input type="checkbox" id="{{ $key }}-group-{{ $index }}"
-                                    class="ons-checkbox__input ons-js-checkbox"
-                                    name="{{ $key }}"
-                                    value="{{ print $filter.Type }}"
-                                    data-gtm-label="{{ $filter.Type }}"
-                                    {{ if $filter.IsChecked }}
-                                        checked
-                                    {{ end }}
-                                >
-                                <label class="ons-checkbox__label" for="{{ $key }}-group-{{ $index }}" id="{{ $key }}-group-{{ $index }}-label">
-                                    {{ $filter.LocaliseKeyName }} ({{ $filter.Count }})
-                                </label>
-                            </span>
+        <details class="ons-collapsible ons-js-details ons-collapsible--accordion" data-group="accordion" data-btn-close="Hide this" data-open="true">
+            <summary class="ons-collapsible__heading ons-js-collapsible-heading">
+                <h2 class="ons-collapsible__title">
+                    <legend class="block">
+                        {{ localise $translationKey $lang 1 }}
+                    </legend>
+                </h2>
+                <span class="ons-collapsible__icon">
+                    {{ template "icons/chevron-right" }}
+                </span>
+            </summary>
+            <div class="ons-collapsible__content ons-js-details-content ons-u-mb-s">
+                {{ range $index, $filter := $value }}
+                <div class="ons-checkboxes__items">
+                    <span class="ons-checkboxes__item ons-checkboxes__item--no-border">
+                        <span class="ons-checkbox ons-checkbox--no-border {{ $key }}">
+                            <input type="checkbox" id="{{ $key }}-group-{{ $index }}"
+                                class="ons-checkbox__input ons-js-checkbox"
+                                name="{{ $key }}"
+                                value="{{ print $filter.Type }}"
+                                data-gtm-label="{{ $filter.Type }}"
+                                {{ if $filter.IsChecked }}
+                                    checked
+                                {{ end }}
+                            >
+                            <label class="ons-checkbox__label" for="{{ $key }}-group-{{ $index }}" id="{{ $key }}-group-{{ $index }}-label">
+                                {{ $filter.LocaliseKeyName }} ({{ $filter.Count }})
+                            </label>
                         </span>
-                    </div>
-                    {{ end }}
+                    </span>
                 </div>
-                <noscript>
-                    <button type="submit"
-                            class="ons-btn ons-btn--primary margin-top-sm--2 margin-top-md--2 js-submit-button">
-                            <span class="ons-btn__inner"><span class="ons-btn__text">{{ localise "Filter" $lang 4}}</span></span>
-                    </button>
-                </noscript>
-            </details>
-    </form>
+                {{ end }}
+            </div>
+        </details>
     {{ end }}
 </div>
 <div class="search__filter__mobile-filter-toggle margin-bottom--8 hide">

--- a/assets/templates/partials/sort.tmpl
+++ b/assets/templates/partials/sort.tmpl
@@ -1,6 +1,6 @@
 {{ $lang := .Language }}
 
-<div class="ons-grid ons-grid--flex@m ons-u-pb-s">
+<div class="ons-grid ons-grid--flex@m">
   <div class="ons-grid__col ons-u-wa--">
     <div class="ons-field--inline">
       <label

--- a/assets/templates/search.tmpl
+++ b/assets/templates/search.tmpl
@@ -29,48 +29,55 @@
       </div>
 
     {{else}}
+      <form id="filterForm" method="get" class="js-auto-submit__form">
+        <div class="ons-grid__col ons-col-12@m">
+          <section class="search__summary" role="contentinfo"  aria-label="{{ localise "SearchSummary" $lang 4 }}">
+            {{ template "partials/summary" . }}
+          </section>
+        </div>
 
-      <div class="ons-grid__col ons-col-12@m">
-        <section class="search__summary" role="contentinfo"  aria-label="{{ localise "SearchSummary" $lang 4 }}">
-          {{ template "partials/summary" . }}
-        </section>
-      </div>
+        <div class="ons-grid__col ons-col-4@m">
+          <section class="search__filter" role="contentinfo" aria-label="{{ localise "SearchFiltering" $lang 4 }}" id="search-filter">
+            <div class="search__filter__heading">
+              <h3 class="font-size--18">
+                {{ localise "Filter" $lang 4 }} {{ localise .Data.TermLocalKey $lang 4 }}
+              </h3>
+              <a href="?{{ if .Data.Query }}q={{ .Data.Query}}{{end}}" id="clear-search" class="float-right font-size--18">{{ localise "ClearAll" $lang 1 }}</a>
+            </div>
+            <div class="search__filter__content ons-u-bb">
+              {{ template "partials/filter" . }}
+            </div>
+            <button
+              type="submit"
+              class="ons-btn ons-u-mt-l ons-u-mb-l text-wrap"
+            >
+              <span class="ons-btn__inner">{{ localise "ApplyFilters" .Language 1 }}</span>
+            </button>
+          </section>
+        </div>
 
-      <div class="ons-grid__col ons-col-4@m">
-        <section class="search__filter" role="contentinfo" aria-label="{{ localise "SearchFiltering" $lang 4 }}" id="search-filter">
-          <div class="search__filter__heading">
-            <h3 class="font-size--18">
-              {{ localise "Filter" $lang 4 }} {{ localise .Data.TermLocalKey $lang 4 }}
-            </h3>
-            <a href="?{{ if .Data.Query }}q={{ .Data.Query}}{{end}}" id="clear-search" class="float-right font-size--18">{{ localise "ClearAll" $lang 1 }}</a>
-          </div>
-          <div class="search__filter__content">
-            {{ template "partials/filter" . }}
-          </div>
-        </section>
-      </div>
-
-      <div class="ons-grid__col ons-col-8@m" aria-live="polite">
-        <section role="contentinfo" aria-label="{{ localise "SearchResults" $lang  1 }}">
-          <div class="search__count">
-            {{ template "partials/count" . }}
-          </div>
-          <div class="search__sort">
-            {{ template "partials/sort" . }}
-          </div>
-          <div class="search__filter__mobile-filter-toggle hide">
-              <button id="filter-results" type="button" class="ons-btn ons-btn--secondary" aria-controls="search-filter">
-                <span class="ons-btn__inner">{{ localise "FilterResults" $lang 4 }}</span>
-              </button>
-          </div>
-          <div class="search__results">
-            {{ template "partials/results" . }}
-          </div>
-          <div class="search__pagination">
-            {{ template "partials/search-pagination" . }}
-          </div>
-        </section>
-      </div>
+        <div class="ons-grid__col ons-col-8@m" aria-live="polite">
+          <section role="contentinfo" aria-label="{{ localise "SearchResults" $lang  1 }}">
+            <div class="search__count">
+              {{ template "partials/count" . }}
+            </div>
+            <div class="search__sort">
+              {{ template "partials/sort" . }}
+            </div>
+            <div class="search__filter__mobile-filter-toggle hide">
+                <button id="filter-results" type="button" class="ons-btn ons-btn--secondary" aria-controls="search-filter">
+                  <span class="ons-btn__inner">{{ localise "FilterResults" $lang 4 }}</span>
+                </button>
+            </div>
+            <div class="search__results">
+              {{ template "partials/results" . }}
+            </div>
+            <div class="search__pagination">
+              {{ template "partials/search-pagination" . }}
+            </div>
+          </section>
+        </div>
+      </form>
     {{end}}
 
   </div>


### PR DESCRIPTION
### What

This was to fix the search dropdown when js is disabled.

I also fixed an issue with search query not being retained when js is disabled and the apply filter button is pressed.

I've made the search page more resemble the aggregated pages.
- Apply filter button at bottom of filters
- Removed individual buttons from filters when js is disabled
- Wrapped all filters in same form tags
- Removed form tags from each filter

### How to review

Pull this branch
Run dp-frontend-search-controller using make debug ENABLE_REWORKED_DATA_AGGREGATION_PAGES=true
Port forward the api router to sandbox with `dp ssh sandbox web 1 -p 23200:localhost:10800`

- http://localhost:25000/search?q=climate

check all filters and sort work.

Turn js off and refresh, and check they still work.

### Who can review

Frontend
