### PR TITLE
Fix switch language on relateddata and previousreleases

### DIFF
--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -118,6 +118,7 @@ func CreatePreviousReleasesPage(cfg *config.Config, req *http.Request, basePage 
 	page.Language = lang
 	page.BetaBannerEnabled = true
 	page.SearchDisabled = false
+	page.URI = req.URL.RequestURI()
 	page.Pagination.CurrentPage = validatedQueryParams.CurrentPage
 	page.ServiceMessage = homepageResponse.ServiceMessage
 	page.EmergencyBanner = mapEmergencyBanner(homepageResponse)

--- a/mapper/related_data.go
+++ b/mapper/related_data.go
@@ -28,6 +28,7 @@ func CreateRelatedDataPage(cfg *config.Config, req *http.Request, basePage coreM
 	page.Language = lang
 	page.BetaBannerEnabled = true
 	page.SearchDisabled = false
+	page.URI = req.URL.RequestURI()
 	page.Pagination.CurrentPage = validatedQueryParams.CurrentPage
 	page.ServiceMessage = homepageResponse.ServiceMessage
 	page.EmergencyBanner = mapEmergencyBanner(homepageResponse)


### PR DESCRIPTION
### What

This [fixes](https://jira.ons.gov.uk/browse/DIS-2001) the switch language not working on /relateddata and /previousreleases

### How to review

You can do `make debug API_ROUTER_URL=https://api.dp.aws.onsdigital.uk/v1`
Then checkout the language switches on these two

- http://localhost:25000/employmentandlabourmarket/peopleinwork/employmentandemployeetypes/bulletins/uklabourmarket/october2023/relateddata
- http://localhost:25000/employmentandlabourmarket/peopleinwork/employmentandemployeetypes/bulletins/uklabourmarket/previousreleases

### Who can review
Anyone
