### PR TITLE
fix/remove related to census

### DIFF
--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -364,7 +364,9 @@ func mapDataPage(page *model.SearchPage, respC *searchModels.SearchResponse, lan
 	}
 
 	page.Type = "Data Aggregation Page"
-	page.Data.Topic = strings.ToLower(topic.LocaliseKeyName)
+	if !strings.EqualFold(topic.LocaliseKeyName, "census") {
+		page.Data.Topic = strings.ToLower(topic.LocaliseKeyName)
+	}
 	page.Data.TermLocalKey = "Results"
 	page.Count = respC.Count
 	page.Language = lang


### PR DESCRIPTION
### What

✅ Remove [related to census](https://jira.ons.gov.uk/browse/DIS-2317) from top level data aggregation pages. Added guard against the default topic of census appearing on the pages

### How to review

Sense check
To run locally:
- Pull this branch and run `make debug ENABLE_AGGREGATION_PAGES=true ENABLE_TOPIC_AGGREGATION_PAGES=true`
- Run the design system `nvm use && npm run dev`
- Port forward the api router to sandbox `dp ssh sandbox web 1 -p 23200:localhost:10800`
- Visit the top level aggregated pages and topic level pages to see the page title is displayed as expected
   - http://localhost:25000/staticlist
   - http://localhost:25000/publishedrequests
   - http://localhost:25000/datalist
   - http://localhost:25000/economy/economicoutputandproductivity/output/datalist
   - http://localhost:25000/alladhocs
   - http://localhost:25000/allmethodologies
   - http://localhost:25000/topicspecificmethodology
   - http://localhost:25000/economy/economicoutputandproductivity/output/publications?filter=bulletin
   - http://localhost:25000/economy/economicoutputandproductivity/output/topicspecificmethodology

### Who can review

!me
