### PR TITLE
Feature/remove content type filters

### DIFF
--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -170,7 +170,6 @@ func mapDataPage(page *model.SearchPage, respC *searchModels.SearchResponse, lan
 	case "home-publications":
 		page.Metadata.Title = "Publications"
 		page.Title.LocaliseKeyName = "HomePublications"
-		page.Data.SingleContentTypeFilterEnabled = true
 		page.RSSLink = generateRSSLink(req.URL.RawQuery)
 	case "all-methodologies":
 		page.Metadata.Title = "All methodology"

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -577,11 +577,10 @@ func TestCreateDataAggregationPage(t *testing.T) {
 					exRSSLink:                        "?rss",
 				},
 				{
-					template:                         "home-publications",
-					exTitle:                          "Publications",
-					exLocaliseKeyName:                "HomePublications",
-					exSingleContentTypeFilterEnabled: true,
-					exRSSLink:                        "?rss",
+					template:          "home-publications",
+					exTitle:           "Publications",
+					exLocaliseKeyName: "HomePublications",
+					exRSSLink:         "?rss",
 				},
 				{
 					template:             "all-methodologies",


### PR DESCRIPTION
### What

[Remove](https://jira.ons.gov.uk/browse/DIS-2791) content type filters from the publication aggregated pages.

### How to review

- Run service with `make debug ENABLE_AGGREGATION_PAGES=true ENABLE_TOPIC_AGGREGATION_PAGES=true`
- Check `/publications` and `/economy/publications` no longer have the Content type filter

![image](https://github.com/user-attachments/assets/2da2f28a-3f2c-4b8b-9409-f5b5a0b1fc94)

![image](https://github.com/user-attachments/assets/cf929f0f-922c-456d-b7f3-3b89044c9571)

### Who can review

!Me
