### PR TITLE
Downgrade client errors logging to info

### DIFF
--- a/apperrors/errors.go
+++ b/apperrors/errors.go
@@ -6,6 +6,8 @@ import (
 
 var (
 	ErrContentTypeNotFound          = errors.New("content type not found")
+	ErrPageTypeIncompatible         = errors.New("page type isn't compatible with related list page")
+	ErrZebedeePageDataNotFound      = errors.New("zebedee page data not found")
 	ErrInternalServer               = errors.New("internal server error")
 	ErrInvalidPage                  = errors.New("invalid page value, exceeding the default maximum search results")
 	ErrInvalidQueryString           = errors.New("the query string did not meet requirements")
@@ -23,7 +25,9 @@ var (
 	}
 
 	NotFoundMap = map[error]bool{
-		ErrTopicPathNotFound: true,
+		ErrTopicPathNotFound:       true,
+		ErrPageTypeIncompatible:    true,
+		ErrZebedeePageDataNotFound: true,
 	}
 
 	// ErrMapForRenderBeforeAPICalls is a list of errors which leads to the search page being rendered before making any API calls

--- a/cache/topic.go
+++ b/cache/topic.go
@@ -116,9 +116,9 @@ func (dc *TopicCache) GetTopic(ctx context.Context, slug, parentSlug string) (*S
 	topicCacheItem, exists := dataTopicCache.List.GetBySlugAndParentSlug(slug, parentSlug)
 	if !exists {
 		err := fmt.Errorf("requested topic with slug %s and parent slug %s does not exist in cache", slug, parentSlug)
-		log.Error(ctx, "failed to get topic from cache", err, log.Data{
-			"topicSlug":  slug,
-			"parentSlug": parentSlug,
+		log.Info(ctx, "topic did not exist in cache", log.Data{
+			"topic_slug":  slug,
+			"parent_slug": parentSlug,
 		})
 		return nil, err
 	}

--- a/data/filter.go
+++ b/data/filter.go
@@ -216,7 +216,7 @@ func reviewFilters(ctx context.Context, urlQuery url.Values, validatedQueryParam
 		if !found {
 			err = errs.ErrContentTypeNotFound
 			logData := log.Data{"requested_filter": filter}
-			log.Error(ctx, "failed to find filter", err, logData)
+			log.Info(ctx, "failed to find filter", logData)
 
 			break
 		}

--- a/data/pagination.go
+++ b/data/pagination.go
@@ -34,7 +34,7 @@ func reviewPagination(ctx context.Context, cfg *config.Config, urlQuery url.Valu
 	// Log and error if expected result is too large
 	if (page * limit) > cfg.DefaultMaximumSearchResults {
 		err := errs.ErrPageExceedsTotalPages
-		log.Error(ctx, "Requested page exceeds maximum search results", err, log.Data{
+		log.Info(ctx, "requested page exceeds maximum search results", log.Data{
 			"page":       page,
 			"limit":      limit,
 			"maxResults": cfg.DefaultMaximumSearchResults,

--- a/data/query.go
+++ b/data/query.go
@@ -94,7 +94,7 @@ func ReviewQuery(ctx context.Context, cfg *config.Config, urlQuery url.Values, c
 
 func handleValidationError(ctx context.Context, err error, description, id string, validationErrs []core.ErrorItem) []core.ErrorItem {
 	if err != nil {
-		log.Error(ctx, description, err)
+		log.Info(ctx, description)
 		validationErrs = append(validationErrs, core.ErrorItem{
 			Description: core.Localisation{
 				Text: err.Error(),

--- a/data/string.go
+++ b/data/string.go
@@ -44,7 +44,7 @@ func checkForNonSpaceCharacters(ctx context.Context, queryString string) error {
 	}
 
 	if !match {
-		log.Warn(ctx, fmt.Sprintf("the query string did not match the regex, %v non-space characters required", minQueryLength))
+		log.Info(ctx, fmt.Sprintf("the query string did not match the regex, %v non-space characters required", minQueryLength))
 		errVal := errs.ErrInvalidQueryCharLengthString
 		return errVal
 	}
@@ -58,7 +58,9 @@ func checkForSpecialCharacters(ctx context.Context, str string) error {
 	match := re.MatchString(str)
 
 	if match {
-		log.Warn(ctx, "the query string contains special characters")
+		log.Info(ctx, "the query string contains special characters", log.Data{
+			"query": str,
+		})
 		errVal := errs.ErrInvalidQueryString
 		return errVal
 	}

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -290,7 +290,10 @@ func validateCurrentPage(ctx context.Context, cfg *config.Config, validatedQuery
 
 		if validatedQueryParams.CurrentPage > totalPages {
 			err := apperrors.ErrPageExceedsTotalPages
-			log.Error(ctx, "current page exceeds total pages", err)
+			log.Info(ctx, "current page exceeds total pages", log.Data{
+				"current_page": validatedQueryParams.CurrentPage,
+				"total_pages":  totalPages,
+			})
 
 			return err
 		}

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -405,7 +405,11 @@ func setStatusCode(w http.ResponseWriter, req *http.Request, err error) {
 		status = http.StatusNotFound
 	}
 
-	log.Error(req.Context(), "setting-response-status", err)
+	log.Info(req.Context(), "setting-response-status")
+
+	if status >= 500 {
+		log.Error(req.Context(), "serving internal error status", err)
+	}
 
 	w.WriteHeader(status)
 }

--- a/handlers/related_data.go
+++ b/handlers/related_data.go
@@ -17,13 +17,6 @@ import (
 	"github.com/ONSdigital/dp-topic-api/models"
 )
 
-// list of content types that have /relateddata
-var knownRelatedDataTypes = []string{
-	"bulletin",
-	"article",
-	"compendium_landing_page",
-}
-
 // RelatedData handler
 func (sh *SearchHandler) RelatedData(cfg *config.Config) http.HandlerFunc {
 	return dphandlers.ControllerHandler(func(w http.ResponseWriter, req *http.Request, lang, collectionID, accessToken string) {


### PR DESCRIPTION
### What

Downgraded several client side errors to info logging as stack trace is not useful here as it's expected behaviour. This means the logs are being clogged up. 

### How to review

Check looks ok, tests pass.

### Who can review

Not me. 