### PR TITLE
fix/update previous releases migration link uri

### DIFF
--- a/features/previousreleases.feature
+++ b/features/previousreleases.feature
@@ -39,7 +39,7 @@ Feature: Previous Releases
     And the search controller is running
     When I GET "/economy/previousreleases"
     Then the HTTP status code should be "308"
-    And the response header "Location" should be "/my-new-bulletin/previous-releases"
+    And the response header "Location" should be "/my-new-bulletin/editions"
 
   Scenario: GET /previousreleases and breadcrumb request errors
     Given there is a Search API that gives a successful response and returns 3 results

--- a/handlers/previous_releases.go
+++ b/handlers/previous_releases.go
@@ -32,7 +32,8 @@ func (sh *SearchHandler) PreviousReleases(cfg *config.Config) http.HandlerFunc {
 		}
 
 		if pageData.Description.MigrationLink != "" {
-			http.Redirect(w, req, pageData.Description.MigrationLink+"/previous-releases", http.StatusPermanentRedirect)
+			migrationLinkURI := pageData.Description.MigrationLink + "/editions"
+			http.Redirect(w, req, migrationLinkURI, http.StatusPermanentRedirect)
 			return
 		}
 

--- a/handlers/previous_releases_test.go
+++ b/handlers/previous_releases_test.go
@@ -38,7 +38,7 @@ func TestUnitReadPreviousReleasesWithMigrationLink(t *testing.T) {
 			Convey("Then a 308 redirect should be returned", func() {
 				w := doTestRequest("/{uri:.*}/previousreleases", req, mockSearchHandler.PreviousReleases(cfg), nil)
 				location := w.Header().Get("Location")
-				expectedLocation := "/my-new-bulletin/previous-releases"
+				expectedLocation := "/my-new-bulletin/editions"
 
 				So(w.Code, ShouldEqual, http.StatusPermanentRedirect)
 				So(location, ShouldEqual, expectedLocation)


### PR DESCRIPTION
### What

Migration link for previous releases has been updated to end in `editions` aka ✅ [Update /previous-releases redirect](https://officefornationalstatistics.atlassian.net/browse/DIS-3502)

### How to review

Sense check

### Who can review

!me
