### PR TITLE
Fix/topic results UX

### DIFF
--- a/assets/templates/partials/data-aggregation-results.tmpl
+++ b/assets/templates/partials/data-aggregation-results.tmpl
@@ -31,7 +31,7 @@
     <ul class="flush--padding">
         {{ range $i, $item := $response.Items }}
             {{ $currentPosition := add $i 1 }}
-            <li class="{{if $enabledTimeSeriesExport }} border-bottom {{end}} search__results__item{{if eq $item.Type.Type `product_page`}} search__results__item--product-page{{end}}">
+            <li class="{{if $enabledTimeSeriesExport }} border-bottom {{end}} search__results__item">
                 <h3>
                     {{if $enabledTimeSeriesExport }}
                         <span class="ons-checkbox ons-checkbox--no-border">

--- a/assets/templates/partials/results.tmpl
+++ b/assets/templates/partials/results.tmpl
@@ -22,7 +22,7 @@
     <ul class="flush--padding">
     {{ range $i, $item := $response.Items }}
         {{ $currentPosition := add $i 1 }}
-        <li class="search__results__item{{if eq $item.Type.Type `product_page`}} search__results__item--product-page{{end}}">
+        <li class="search__results__item">
             <h3>
                 <a href="{{ .URI }}"
                     data-gtm-search-result-title="{{ .Description.Title }}"

--- a/assets/templates/partials/results.tmpl
+++ b/assets/templates/partials/results.tmpl
@@ -65,22 +65,6 @@
                     {{ end }}
                 </dl>
             {{ end }}
-            {{if eq $item.Type.Type `product_page`}}
-                <p class="search__results__summary--product-page font-size--16">
-                    View all <a href="{{ .URI }}#datasets">datasets</a> or <a href="{{ .URI }}#publications">publications</a> related to 
-                    <a href="{{ .URI }}"
-                        data-gtm-search-result-title="{{ .Description.Title }}"
-                        data-gtm-search-result-page="{{ $currentPage }}"
-                        data-gtm-search-result-position="{{ add $totalSearchPosition $currentPosition }}"
-                        data-gtm-search-result-url="{{ .URI }}"
-                        data-gtm-search-result-release-date="{{ dateFormatYYYYMMDDNoSlashes .Description.ReleaseDate }}"
-                    >
-                        {{ .Description.Title | safeHTML }}
-                        {{ if .Description.Edition }}:{{ end }}
-                        {{ .Description.Edition | safeHTML }}
-                    </a>
-                </p>
-            {{end}}
         </li>
     {{end}}
     </ul>


### PR DESCRIPTION
### What

[UX fix for topic pages surfacing in Search results
](https://officefornationalstatistics.atlassian.net/browse/DIS-4768)

### How to review

- Looks okay
- Port forward to staging web_mount of api router
- Run `dp-design-system` for styles 
- Review the results 
```sh
http://localhost:25000/search?q=UK+trade&sort=release_date&page=1
```
- The last sentence with the product links should be removed
- No grey border around result 
  
### Who can review

!Me