### PR TITLE
Remove census topics error message

### DIFF
--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -271,10 +271,6 @@ one = "Nid oes unrhyw ganlyniadau cyfatebol"
 description = "Select another topic"
 one = "Dewis pwnc arall"
 
-[NoResultsBody]
-description = "Not all census content has been released. Check for upcoming releases in the <a href=\"/releasecalendar\">release calendar</a>. Alternatively, you can create a <a href=\"/datasets/create\">custom dataset</a>."
-one = "Nid yw holl gynnwys y cyfrifia wedi'i ryddhau. Edrychwch am ddatganiadau sydd i ddod ar y <a href=\"/releasecalendar\">calendr datganiadau</a>. Fel arall, gallwch <a href=\"/datasets/create\">greu set ddata eich fun</a>."
-
 [FindCensusData]
 description = "Find Census Data"
 one = "Cael setiau data’r cyfrifiad"

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -272,10 +272,6 @@ one = "Sorry, there are no matching results."
 description = "Select another topic"
 one = "Select another topic"
 
-[NoResultsBody]
-description = "Not all census content has been released. Check for upcoming releases in the <a href=\"/releasecalendar\">release calendar</a>. Alternatively, you can create a <a href=\"/datasets/create\">custom dataset</a>."
-one = "Not all census content has been released. Check for upcoming releases in the <a href=\"/releasecalendar\">release calendar</a>. Alternatively, you can create a <a href=\"/datasets/create\">custom dataset</a>."
-
 [FindCensusData]
 description = "Find Census Data"
 one = "Find Census Data"

--- a/assets/templates/partials/results.tmpl
+++ b/assets/templates/partials/results.tmpl
@@ -17,7 +17,6 @@
     <div id="results-zero" class="hide">
         <h3>{{ localise "NoResultsHeader" $lang 1 }}</h3>
         <p>{{ localise "NoResultsSelectAnother" $lang 1 }} {{ localise "Or" $lang 1 }} <a href="?{{ if .Data.Query }}q={{ .Data.Query}}{{end}}" id="clear-search-zero">{{ localise "ClearAllFilters" $lang 1 }}</a>.</p>
-        <p>{{ localise "NoResultsBody" $lang 1 | safeHTML}}</p>
     </div>
     <ul class="flush--padding">
     {{ range $i, $item := $response.Items }}


### PR DESCRIPTION
### What

[Fix search Census topics error message
](http://officefornationalstatistics.atlassian.net/browse/DPD-4631)

### How to review

- Looks okay
- Check `NoResultsBody` is not used anywhere else
- Port forward to sandbox web_mount of api router
- Run `dp-design-system` for styles 
- Review search result and click `Census`
```sh
http://localhost:25000/search?q=retail+sales
```
- No additional error message as specified in ticket
  
### Who can review

!Me